### PR TITLE
Support (1:3)*mm

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -331,6 +331,9 @@ end
 # Kind of weird, but okay, no need to make things noncommutative.
 *(x::Units, y::Number) = *(y,x)
 
+*(r::Range, y::Units) = range(first(r)*y, step(r)*y, length(r))
+*(r::Range, y::Units, z::Units...) = *(x, *(y,z...))
+
 # These six are defined for use in `*(a0::Unitlike, a::Unitlike...)`
 unit{S}(x::Unit{S}) = S
 unit{S}(x::Dimension{S}) = S

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -349,6 +349,12 @@ end
     #         @test isa(collect(1.0m:2m:10m), Array{typeof(1.0m),1})
     #         @test isa(collect(linspace(1.0m,10.0m,5)), Array{typeof(1.0m),1})
     #     end
+
+        @testset ">> unit multiplication" begin
+            @test @inferred((1:5)*mm) === 1mm:1mm:5mm
+            @test @inferred((1:2:5)*mm) === 1mm:2mm:5mm
+            @test @inferred((1.0:2.0:5.01)*mm) === 1.0mm:2.0mm:5.0mm
+        end
     end
 
     @testset "> Arrays" begin


### PR DESCRIPTION
Given previous discussions and my opposition to unitful UnitRanges: note this creates a StepRange and is effectively shorthand for `1mm:1mm:3mm`, so I'm not being inconsistent here. I'd still complain if this returned a `UnitRange` :wink:.
