### PR TITLE
Simplify creation of typed arrays: `[1, 2]u"km"`

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -472,7 +472,7 @@ end
 .\(X::AbstractArray, y::Units) =
     reshape([ x .\ y for x in X ], size(X))
 
-for f in (:.*,) # looked in arraymath.jl for similar code
+for f in (:.*, :*) # looked in arraymath.jl for similar code
     @eval begin
         function ($f){T}(A::Units, B::AbstractArray{T})
             F = similar(B, promote_op($f,typeof(A),T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -386,6 +386,9 @@ end
             @test @inferred([1V, 2V] .* [true, false]) == [1V, 0V]
             @test @inferred([1.0m, 2.0m] ./ 3)         == [1m/3, 2m/3]
             @test @inferred([1V, 2.0V] ./ [3m, 4m])    == [1V/(3m), 0.5V/m]
+
+            @test @inferred([1, 2]kg)                  == [1, 2] * kg
+            @test @inferred([1, 2]kg .* [2, 3]kg^-1)   == [2, 6]
         end
 
         @testset ">> Array addition" begin


### PR DESCRIPTION
It's already possible for quantities `[1, 1] * 1u"m"`, and `[1, 1] .* u"m"` is also explicitly  declared. So adds it for `*`.