### PR TITLE
Performance benchmarks

### DIFF
--- a/test/benchmarks.jl
+++ b/test/benchmarks.jl
@@ -23,17 +23,33 @@ benchmark(expression::Expr) =
     benchmark!(BenchmarkGroup(["Unitful"]), expression)
 
 function performance_summary(suite)
+    tune!(suite)
     benchs = run(suite)
-    result = DataFrame(op=Symbol[], expression=String[], performance=Float64[])
+    result = DataFrame(op=Symbol[], expression=String[],
+                       ratio=Float64[], time=Any[], memory=Any[])
     for op in keys(benchs)
         for expression in keys(benchs[op])
-            units = benchs[op][expression][:units]
-            nounits = benchs[op][expression][:nounits]
+            units = median(benchs[op][expression][:units])
+            nounits = median(benchs[op][expression][:nounits])
+            rt = ratio(units, nounits).time
+            judgment = judge(units, nounits)
             push!(
                 result,
-                [op, expression, ratio(median(units), median(nounits)).time]
+                [op, expression, rt, judgment.time, judgment.memory]
             )
         end
     end
     result
 end
+
+function benchmark()
+    suite = BenchmarkGroup(["Unitful"])
+    for a in (2u"m", 2.1u"m"), b in (3u"kg", 3.5u"kg"), op in (:*, :/)
+      benchmark!(suite, :($op($a, $b)))
+    end
+    # for a in (2u"m", 1//2u"m"), b in (1//3u"kg"), op in (:*, :+, :-, ://)
+    #     benchmark!(suite, :($op($a, $b)))
+    # end
+    performance_summary(suite)
+end
+

--- a/test/benchmarks.jl
+++ b/test/benchmarks.jl
@@ -1,55 +1,52 @@
 using Unitful
 using BenchmarkTools
+using Base.Test
 using DataFrames
-
-function benchmark!(suite::BenchmarkGroup, expression::Expr)
-    @assert expression.head == :call
-    op = expression.args[1]
-    a = eval(expression.args[2])
-    b = eval(expression.args[3])
-    if op ∉ keys(suite)
-      suite[op] = BenchmarkGroup()
-    end
-    name = "$a $op $b"
-    if name ∉ keys(suite[op])
-        suite[op][name] = BenchmarkGroup([op])
-    end
-    suite[op][name][:units] = @benchmarkable $op($a, $b)
-    suite[op][name][:nounits] =
-        @benchmarkable $op($(ustrip(a)), $(ustrip(b)))
-    suite
-end
-benchmark(expression::Expr) =
-    benchmark!(BenchmarkGroup(["Unitful"]), expression)
-
-function performance_summary(suite)
-    tune!(suite)
-    benchs = run(suite)
-    result = DataFrame(op=Symbol[], expression=String[],
-                       ratio=Float64[], time=Any[], memory=Any[])
-    for op in keys(benchs)
-        for expression in keys(benchs[op])
-            units = median(benchs[op][expression][:units])
-            nounits = median(benchs[op][expression][:nounits])
-            rt = ratio(units, nounits).time
-            judgment = judge(units, nounits)
-            push!(
-                result,
-                [op, expression, rt, judgment.time, judgment.memory]
-            )
-        end
-    end
-    result
-end
 
 function benchmark()
     suite = BenchmarkGroup(["Unitful"])
-    for a in (2u"m", 2.1u"m"), b in (3u"kg", 3.5u"kg"), op in (:*, :/)
+    bterms = (3u"kg", 3.5u"kg", 2u"m^-1")
+    for a in (2u"m", 2.1u"m"), b in bterms, op in (:*, :/)
       benchmark!(suite, :($op($a, $b)))
     end
-    # for a in (2u"m", 1//2u"m"), b in (1//3u"kg"), op in (:*, :+, :-, ://)
-    #     benchmark!(suite, :($op($a, $b)))
-    # end
+    for a in (2u"m", 2.1u"m"), b in (3u"m", 3.5u"m"), op in (:+, :-)
+        benchmark!(suite, :($op($a, $b)))
+    end
+
     performance_summary(suite)
 end
 
+function judge_unit_benchmark(units::Expr, nounits::Expr; kwargs...)
+    bench_units = @benchmarkable $units
+    bench_nounits = @benchmarkable $nounits
+    tune!(bench_units)
+    tune!(bench_nounits)
+    judge(
+        median(run(bench_units; kwargs...)),
+        median(run(bench_nounits; kwargs...))
+    )
+end
+
+function judge_unit_benchmark(units::Expr; kwargs...)
+    op = units.args[1]
+    a = ustrip(eval(units.args[2]))
+    b = ustrip(eval(units.args[3]))
+    judge_unit_benchmark(units, :($op($a, $b)); kwargs...)
+end
+
+function test_benchmark(unit::Expr...; kwargs...)
+    j = judge_unit_benchmark(unit...; kwargs...)
+    j.time == :invariant && j.memory == :invariant
+end
+
+@testset "Benchmarks" begin
+    as, ops, bs = (2u"m", 2.1u"m"), (:*, :/), (3u"kg", 3.5u"kg", 2u"m^-1")
+    # @testset "$a $op $b" for a = as, b = bs, op = ops
+    #     @test test_benchmark(:($op($a, $b)))
+    # end
+
+    @testset "dimensionless to unitless" begin
+        @test test_benchmark(:(1u"m" / 2u"m"))
+        @test test_benchmark(:(1u"m" * 2u"m^-1"))
+    end
+end

--- a/test/benchmarks.jl
+++ b/test/benchmarks.jl
@@ -1,0 +1,39 @@
+using Unitful
+using BenchmarkTools
+using DataFrames
+
+function benchmark!(suite::BenchmarkGroup, expression::Expr)
+    @assert expression.head == :call
+    op = expression.args[1]
+    a = eval(expression.args[2])
+    b = eval(expression.args[3])
+    if op ∉ keys(suite)
+      suite[op] = BenchmarkGroup()
+    end
+    name = "$a $op $b"
+    if name ∉ keys(suite[op])
+        suite[op][name] = BenchmarkGroup([op])
+    end
+    suite[op][name][:units] = @benchmarkable $op($a, $b)
+    suite[op][name][:nounits] =
+        @benchmarkable $op($(ustrip(a)), $(ustrip(b)))
+    suite
+end
+benchmark(expression::Expr) =
+    benchmark!(BenchmarkGroup(["Unitful"]), expression)
+
+function performance_summary(suite)
+    benchs = run(suite)
+    result = DataFrame(op=Symbol[], expression=String[], performance=Float64[])
+    for op in keys(benchs)
+        for expression in keys(benchs[op])
+            units = benchs[op][expression][:units]
+            nounits = benchs[op][expression][:nounits]
+            push!(
+                result,
+                [op, expression, ratio(median(units), median(nounits)).time]
+            )
+        end
+    end
+    result
+end


### PR DESCRIPTION
I've added a number of benchmarks in a file, to check whether operations between unitful objects are just as fast as their unitless counterparts.

Unfortunately, this is not always the case (assuming the code in the pull-request is correct :) ). Most notably, operations involving unitful arrays are quite expensive. 

Not sure whether you want this in the code itself.
The benchmarks are arranged as tests, and can be run with:

```Julia
include("test/benchmarks.jl")
```

Benchmarks can be trialed in the REPL with: 

```Julia
judge_unit_benchmark(:((2u"m") * (2u"m^-1")))
```