### PR TITLE
First attempt at a simplification mechanism

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -204,6 +204,9 @@ else
                 end
             end
         end
+
+        # Defines units preferred by the SI
+        const SI = (m, s, A, K, cd, kg, mol)
         """)
     end
 end

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -23,6 +23,7 @@ export @dimension, @derived_dimension, @refunit, @unit, @u_str
 export Quantity
 export DimensionlessQuantity
 export NoUnits, NoDims
+export simplify
 
 include("Types.jl")
 include("User.jl")
@@ -888,6 +889,7 @@ include("Display.jl")
 include("Promotion.jl")
 include("Conversion.jl")
 include("fastmath.jl")
+include("VectorialSpace.jl")
 
 defpath = joinpath(dirname(dirname(@__FILE__)),"deps","Defaults.jl")
 if isfile(defpath)

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -24,6 +24,7 @@ export Quantity
 export DimensionlessQuantity
 export NoUnits, NoDims
 export simplify
+export SI
 
 include("Types.jl")
 include("User.jl")

--- a/src/VectorialSpace.jl
+++ b/src/VectorialSpace.jl
@@ -1,0 +1,195 @@
+"""
+```
+dimensional_space{Us <: Units}(::Type{Us})
+dimensional_space(units::Units)
+```
+
+Aggregates the dimensions present in the units (whether or not they cancel out).
+
+```jldoctest
+julia> dimensional_space(u"m/km")
+Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}
+
+julia> dimensional_space(u"m/s")
+Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),Unitful.Dimension{:Time}(1//1))}
+
+julia> dimensional_space(u"m/s*J")
+Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),Unitful.Dimension{:Mass}(1//1),Unitful.Dimension{:Time}(1//1))}
+
+julia> dimensional_space(u"m/m")
+Unitful.Dimensions{()}
+```
+"""
+function dimensional_space{Us <: Units}(::Type{Us})
+    directions = Set{Dimension}()
+    for u in Us.parameters[1]
+        for d in typeof(dimension(u)).parameters[1]
+            push!(directions, typeof(d)(1))
+        end
+    end
+    length(directions) == 0 && return Dimensions{()}
+    typeof(prod(Dimensions{(d,)}() for d in directions))
+end
+dimensional_space(u::Units) = dimensional_space(typeof(u))
+
+"""
+```
+dimensional_points{Us <: Units}(::Type{Us}, dimspace::Dimensions)
+dimensional_points{Us <: Units}(::Type{Us})
+dimensional_points(units::Units)
+```
+
+Transforms input unit to vectorial format, where each component in the vector is
+the power of a separate dimension.
+
+Returns a matrix where each row corresponds to a direction and each column to a
+unit, and the second element is a tuple of dimensions (or row-labels)
+
+```jldoctest
+julia> dimensional_points(u"J*m/s")
+3×3 Array{Rational{Int64},2}:
+  2//1  1//1   0//1
+  1//1  0//1   0//1
+ -2//1  0//1  -1//1
+```
+"""
+function dimensional_points{Us <: Units, D <: Dimensions}(::Type{Us},
+    dimspace::Type{D})
+    # return eltype
+    const rtype = typeof(Dimension{:Length}(1).power)
+
+    const ndims = length(dimspace.parameters[1])
+    result = zeros(rtype, (ndims, length(Us.parameters[1])))
+    length(result) == 0 && return result
+
+    for column in 1:size(result, 2)
+        const unit = Us.parameters[1][column]
+        for dim in typeof(dimension(unit)).parameters[1]
+            const index = findfirst(dimspace.parameters[1], typeof(dim)(1))
+            @assert index ≠ 0
+            result[index, column] = dim.power
+        end
+    end
+
+    result
+end
+
+dimensional_points{Us <: Units}(::Type{Us}) =
+    dimensional_points(Us, dimensional_space(Us))
+
+dimensional_points(u::Units) = dimensional_points(typeof(u))
+
+"""
+```
+independant_columns(matrix::Matrix)
+```
+
+Indices of a set of linearly independant column vectors, with a preference
+towards columns that have smaller norms.
+"""
+function independant_columns(matrix::Matrix)
+    size(matrix, 2) == 0 && return Int64[]
+    result = two_by_two_independant(matrix)
+
+    sort!(result, by=i->norm(matrix[:, i]))
+    freaking_rational_units(x) = det(convert(typeof(x), transpose(x) * x))
+    while abs(freaking_rational_units(matrix[:, result])) ≈ 0
+        pop!(result)
+    end
+    sort!(result)
+    result
+end
+
+"""
+```
+two_by_two_independant(matrix::Matrix)
+```
+
+Indices of a set of column vectors, with a preference towards columns that have
+smaller norms, such that no two column vectors are exactly colinear.
+"""
+function two_by_two_independant(matrix::Matrix)
+    size(matrix, 2) == 0 && return Int64[]
+    result = Int64[1]
+    for i in 2:size(matrix, 2)
+        const equiv = findfirst(result) do u
+            const coeff = (matrix[:, i] ⋅ matrix[:, u]) //
+            (matrix[:, u] ⋅ matrix[:, u])
+            all((matrix[:, i] - coeff * matrix[:, u]) .== 0)
+        end
+        if equiv == 0
+            push!(result, i)
+        elseif norm(matrix[:, equiv]) > norm(matrix[:, i])
+            result[equiv] == i
+        end
+    end
+    result
+end
+
+"""
+```
+project_on_basis(vector::Vector, matrix::Matrix; itermax=10, tolerance=0)
+```
+
+Describe a vector using a basis which may or may not be orthogonal.
+"""
+function project_on_basis(vector::Vector, matrix::Matrix;
+                          itermax=10, tolerance=0)
+    if itermax == 0 itermax = typemax(itermax); end
+    result = zeros(promote_type(eltype(vector), eltype(matrix)), size(matrix, 2))
+    current = convert(typeof(result), copy(vector))
+    for iter in 1:itermax
+        for i in 1:size(matrix, 2)
+            const column = vec(matrix[:, i])
+            const coeff = current ⋅ column / (column ⋅ column)
+            result[i] += coeff
+            current -= coeff * column
+        end
+        (current ⋅ current) == 0 && break
+        tolerance > 0 && norm(current) < tolerance && break
+    end
+    result, current ⋅ current
+end
+
+"""
+```
+simplify{Us <: Units}(::Type{Us})
+simplify(u::Units)
+simplify(q::Quantity)
+```
+
+Figures out an equivalent but minimal set of units for the input.
+
+
+```jldoctest
+julia> simplify(1u"cm")
+1 cm
+
+julia> simplify(1u"cm/m")
+1//100
+
+julia> simplify(1u"m*m*km*J/cm")
+100000000000//1 J cm^2
+
+julia> simplify(1u"m*m*km*J/cm/N")
+100000000000//1 cm^3
+```
+"""
+function simplify{Us <: Units}(::Type{Us})
+    dimensions_as_matrix = dimensional_points(Us)
+    current = vec(sum(dimensions_as_matrix, 2))
+    result = Units[]
+    basis_indices = independant_columns(dimensions_as_matrix)
+    projection, residual = project_on_basis(
+        convert(Vector{Rational{BigInt}}, current),
+        dimensions_as_matrix[:, basis_indices]; tolerance=1e-50, itermax=1000)
+
+    const units = Us.parameters[1][basis_indices]
+    prod(
+        Units{(unit,), dimension(unit)}()^coeff
+        for (unit, coeff) in zip(units, round(Rational{Int64}, projection))
+    )
+end
+
+simplify(u::Units) = simplify(typeof(u))
+simplify(q::Quantity) = uconvert(simplify(unit(q)), q)

--- a/src/VectorialSpace.jl
+++ b/src/VectorialSpace.jl
@@ -28,9 +28,10 @@ function dimensional_space{Us <: Units}(::Type{Us})
             push!(directions, typeof(d)(1))
         end
     end
-    length(directions) == 0 && return Dimension[]
-    collect(Dimension,
-		typeof(prod(Dimensions{(d,)}() for d in directions)).parameters[1])
+    result = Dimension[]
+	length(directions) == 0 && return result
+	const dimensions = prod(Dimensions{(d,)}() for d in directions)
+    append!(result, typeof(dimensions).parameters[1])
 end
 dimensional_space(u::Units) = dimensional_space(typeof(u))
 
@@ -56,9 +57,10 @@ function dimensional_space(args::Vararg{Units})
 			end
 		end
     end
-	length(directions) == 0 && return Dimensions{()}
-	collect(Dimension,
-		typeof(prod(Dimensions{(d,)}() for d in directions)).parameters[1])
+	result = Dimension[]
+	length(directions) == 0 && return result
+	const dimensions = prod(Dimensions{(d,)}() for d in directions)
+	append!(result, typeof(dimensions).parameters[1])
 end
 
 """

--- a/src/VectorialSpace.jl
+++ b/src/VectorialSpace.jl
@@ -28,10 +28,61 @@ function dimensional_space{Us <: Units}(::Type{Us})
             push!(directions, typeof(d)(1))
         end
     end
-    length(directions) == 0 && return Dimensions{()}
-    typeof(prod(Dimensions{(d,)}() for d in directions))
+    length(directions) == 0 && return Dimension[]
+    collect(Dimension,
+		typeof(prod(Dimensions{(d,)}() for d in directions)).parameters[1])
 end
 dimensional_space(u::Units) = dimensional_space(typeof(u))
+
+"""
+```
+dimensional_space(units::Vararg{Units})
+```
+
+```jldoctest
+julia> dimensional_space(u"m/km", u"m")
+Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}
+
+julia> dimensional_space(u"m", u"s")
+Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),Unitful.Dimension{:Time}(1//1))}
+```
+"""
+function dimensional_space(args::Vararg{Units})
+	directions = Set{Dimension}()
+	for u in args
+		for param in typeof(u).parameters[1]
+			for d in typeof(dimension(param)).parameters[1]
+				push!(directions, typeof(d)(1))
+			end
+		end
+    end
+	length(directions) == 0 && return Dimensions{()}
+	collect(Dimension,
+		typeof(prod(Dimensions{(d,)}() for d in directions)).parameters[1])
+end
+
+"""
+```
+dimensional_vector(unit::Unit, dspace::Vector{Dimension})
+```
+
+Transforms the input unit into a vector in the space of dimensions.
+"""
+function dimensional_vector(unit::Unit, dspace::Vector{Dimension})
+	const rtype = typeof(Dimension{:Length}(1).power)
+	const ndims = length(dspace)
+	result = zeros(rtype, ndims)
+	length(result) == 0 && return result
+
+	for dim in typeof(dimension(unit)).parameters[1]
+		const index = findfirst(dspace, typeof(dim)(1))
+		index ≠ 0 || error("$dim not found in input dimensional space")
+		result[index] = dim.power
+	end
+	result
+end
+dimensional_vector{Us <: Units}(::Type{Us}, dspace::Vector{Dimension}) =
+	sum(dimensional_vector(u, dspace) for u in Us.parameters[1])
 
 """
 ```
@@ -54,28 +105,21 @@ julia> dimensional_matrix(u"J*m/s")
  -2//1  0//1  -1//1
 ```
 """
-function dimensional_matrix{Us <: Units}(::Type{Us})
-    const dimspace = dimensional_space(Us)
-    # return eltype
-    const rtype = typeof(Dimension{:Length}(1).power)
+dimensional_matrix{Us <: Units}(::Type{Us}, dspace::Vector{Dimension}) =
+	dimensional_matrix(collect(Unit, Us.parameters[1]), dspace)
 
-    const ndims = length(dimspace.parameters[1])
-    result = zeros(rtype, (ndims, length(Us.parameters[1])))
-    length(result) == 0 && return result
-
-    for column in 1:size(result, 2)
-        const unit = Us.parameters[1][column]
-        for dim in typeof(dimension(unit)).parameters[1]
-            const index = findfirst(dimspace.parameters[1], typeof(dim)(1))
-            @assert index ≠ 0
-            result[index, column] = dim.power
-        end
-    end
-
-    result
-end
-
+dimensional_matrix{Us <: Units}(::Type{Us}) =	
+	dimensional_matrix(Us, dimensional_space(Us))
 dimensional_matrix(u::Units) = dimensional_matrix(typeof(u))
+
+function dimensional_matrix(units::Vector{Unit}, dspace::Vector{Dimension})
+	length(units) == 0 && return Matrix{typeof(Dimension{:Length}(1).power)}()
+	hcat(collect(dimensional_vector(u, dspace) for u in units)...)
+end
+function dimensional_matrix(units::Vector{Units}, dspace::Vector{Dimension})
+	length(units) == 0 && return Matrix{typeof(Dimension{:Length}(1).power)}()
+	hcat(collect(dimensional_matrix(typeof(u), dspace) for u in units)...)
+end
 
 """
 ```
@@ -112,11 +156,11 @@ independant_columns(matrix::Matrix)
 Indices of a set of linearly independant column vectors, with a preference
 towards columns that have smaller norms.
 """
-function independant_columns(matrix::Matrix)
+function independant_columns(matrix::Matrix; dosort=true)
     result = two_by_two_independant(matrix)
     (length(result) == 0 || size(matrix, 1) == 0) && return result
 
-    sort!(result, by=i->norm(matrix[:, i]))
+    dosort && sort!(result, by=i->norm(matrix[:, i]))
     freaking_rational_units(x) = det(convert(typeof(x), transpose(x) * x))
     while abs(freaking_rational_units(matrix[:, result])) ≈ 0
         pop!(result)
@@ -151,6 +195,24 @@ function project_on_basis(vector::Vector, matrix::Matrix;
     result, current ⋅ current
 end
 
+""" Private implementation function for simplify """
+function simplify_impl{Us <: Units}(::Type{Us}, asmatrix::Matrix,
+                                    dspace::Vector{Dimension},
+                                    uspace::Vector{Unit})
+    current = dimensional_vector(Us, dspace)
+    result = Units[]
+    const basis_indices = independant_columns(asmatrix, dosort=false)
+    const projection, residual = project_on_basis(
+        convert(Vector{Rational{BigInt}}, current),
+        asmatrix[:, basis_indices]; tolerance=1e-50, itermax=1000)
+
+	const units = uspace[basis_indices]
+    prod(
+        Units{(unit,), dimension(unit)}()^coeff
+        for (unit, coeff) in zip(units, round(Rational{Int64}, projection))
+    )
+end
+
 """
 ```
 simplify{Us <: Units}(::Type{Us})
@@ -161,35 +223,41 @@ simplify(q::Quantity)
 Figures out an equivalent but minimal set of units for the input.
 
 
-```jldoctest
-julia> simplify(1u"cm")
-1 cm
+	```jldoctest
+	julia> simplify(1u"cm")
+	1 cm
 
-julia> simplify(1u"cm/m")
-1//100
+	julia> simplify(1u"cm/m")
+	1//100
 
-julia> simplify(1u"m*m*km*J/cm")
-100000000000//1 J cm^2
+	julia> simplify(1u"m*m*km*J/cm")
+	100000000000//1 J cm^2
 
-julia> simplify(1u"m*m*km*J/cm/N")
-100000000000//1 cm^3
-```
-"""
+	julia> simplify(1u"m*m*km*J/cm/N")
+	100000000000//1 cm^3
+	```
+	"""
 function simplify{Us <: Units}(::Type{Us})
-    dimensions_as_matrix = dimensional_matrix(Us)
-    current = vec(sum(dimensions_as_matrix, 2))
-    result = Units[]
-    basis_indices = independant_columns(dimensions_as_matrix)
-    projection, residual = project_on_basis(
-        convert(Vector{Rational{BigInt}}, current),
-        dimensions_as_matrix[:, basis_indices]; tolerance=1e-50, itermax=1000)
-
-    const units = Us.parameters[1][basis_indices]
-    prod(
-        Units{(unit,), dimension(unit)}()^coeff
-        for (unit, coeff) in zip(units, round(Rational{Int64}, projection))
+	const dspace = dimensional_space(Us)
+	const matrix = dimensional_matrix(Us, dspace)
+    const indices = sort(1:size(matrix, 2), by=i->norm(matrix[:, i]))
+	simplify_impl(Us, matrix[:, indices], dspace,
+                  collect(Unit, Us.parameters[1])[indices])
+end
+function simplify{Us <: Units}(::Type{Us}, preferred::Vector{Units})
+	const dspace = dimensional_space(Us(), preferred...)
+	const matrix_Us = dimensional_matrix(Us, dspace)
+	const indices = sort(1:size(matrix_Us, 2), by=i->norm(matrix_Us[:, i]))
+	const matrix = hcat(dimensional_matrix(preferred, dspace), matrix_Us)
+    const uspace = vcat(
+        (collect(Unit, typeof(u).parameters[1]) for u in preferred)...,
+		collect(Unit, Us.parameters[1])[indices]
     )
+    simplify_impl(Us, matrix, dspace, uspace)
 end
 
-simplify(u::Units) = simplify(typeof(u))
-simplify(q::Quantity) = uconvert(simplify(unit(q)), q)
+
+simplify{Us <: Units}(::Type{Us}, preferred::Tuple) =
+	simplify(Us, collect(Units, preferred))
+simplify(u::Units, args...) = simplify(typeof(u), args...)
+simplify(q::Quantity, args...) = uconvert(simplify(unit(q), args...), q)

--- a/test/vectorial.jl
+++ b/test/vectorial.jl
@@ -1,0 +1,81 @@
+using Base.Test
+using Unitful: dimensional_space, Dimensions, Dimension, dimensional_matrix,
+    two_by_two_independant, independant_columns, project_on_basis, @u_str,
+    simplify
+@testset "Type simplification" begin
+    @testset "> Actual simplification" begin
+        @test simplify(u"cm") === u"cm"
+        @test simplify(2u"cm") === 2u"cm"
+        @test simplify(u"cm/m") == u"m/m"
+        @test simplify(1u"cm/m") == 1//100
+        @test simplify(2.4u"cm/m") == 2.4 * 1//100
+        @test simplify(u"m*m*km*J/cm") == u"J*cm^2"
+        @test simplify(1u"m*m*km*J/cm") == 1000000000//1 * u"J*cm^2"
+		@test 1u"m*m*km*J/cm" == 1000000000//1 * u"J*cm^2"
+		@test simplify(u"m*m*km*J/cm/N") == u"cm^3"
+		@test simplify(2u"m*m*km*J/cm/N") == 200000000000//1 *u"cm^3"
+		@test 1u"m*m*km*J/cm/N" == 100000000000//1 *u"cm^3"
+    end
+
+    @testset "> Count dimensions in a unit" begin
+        @test dimensional_space(u"m/m") === Dimensions{()}
+        @test dimensional_space(u"m/km") ===
+            Dimensions{(Dimension{:Length}(1//1),)}
+        @test dimensional_space(u"m/s") ===
+            Dimensions{(Dimension{:Length}(1//1), Dimension{:Time}(1//1))}
+        @test dimensional_space(u"m/s*J") ===
+            Dimensions{(
+                    Dimension{:Length}(1//1),
+                    Dimension{:Mass}(1//1),
+                    Dimension{:Time}(1//1)
+            )}
+    end
+
+    @testset "> Transform unit to matrix format" begin
+        @test size(dimensional_matrix(u"m/m")) == (0, 0)
+        @test dimensional_matrix(u"m/km") == [1//1 -1//1]
+        @test dimensional_matrix(u"m/km*s") == [1//1 -1//1 0;0 0 1//1]
+        @test dimensional_matrix(u"m/km*s/J") ==
+            [-2//1 1//1 -1//1 0;-1//1 0 0 0; 2//1 0 0 1//1]
+    end
+
+    @testset "> Math" begin
+        @testset ">> No two columns are colinear" begin
+           @test two_by_two_independant(Matrix{Rational{Int}}()) == Int64[]
+           @test two_by_two_independant([1 1; 1 1][2:1, :]) == [1, 2]
+           @test two_by_two_independant([1 1; 1 1][:, 2:1]) == []
+           @test two_by_two_independant([1 1; 1 1]) == [1]
+           @test two_by_two_independant([1 1; 1 12]) == [1, 2]
+           @test two_by_two_independant(transpose([1 1; 8 8; 2 12; 1 6])) ==
+                    [1, 3]
+           @test two_by_two_independant([1 0 1; 0 1 1]) == [1, 2, 3]
+        end
+
+        @testset ">> All the columns are linearly independant" begin
+            @test independant_columns(Matrix{Rational{Int}}()) == Int64[]
+            @test independant_columns([1 1; 1 1][2:1, :]) == [1, 2]
+            @test independant_columns([1 1; 1 1][:, 2:1]) == []
+            @test independant_columns([1 1; 1 1]) == [1]
+            @test independant_columns([1 0 1; 0 1 1]) == [1, 2]
+            @test independant_columns([1 0 1; 2 1 0]) == [2, 3]
+        end
+
+        @testset ">> Project a vector on an orthogonal basis" begin
+            vector = [1, 2]
+            matrix = [1 -1; 1 1]
+            proj, res = project_on_basis(vector, matrix)
+            @test res == 0
+            @test sum(proj[i] * matrix[:, i] for i in 1:size(matrix, 2)) ≈
+                vector
+        end
+
+        @testset ">> Project a vector on a non-orthogonal basis" begin
+            vector = [1, 2]
+            matrix = [1 0; 1 1]
+            proj, res = project_on_basis(vector, matrix; itermax=30)
+            @test_approx_eq_eps res 0 1e-12
+            @test sum(proj[i] * matrix[:, i] for i in 1:size(matrix, 2)) ≈
+                vector
+        end
+    end
+end

--- a/test/vectorial.jl
+++ b/test/vectorial.jl
@@ -6,8 +6,9 @@ using Unitful: dimensional_space, Dimensions, Dimension, dimensional_matrix,
 @testset "Type simplification - implementation" begin
     @testset "> Count dimensions in a unit" begin
         @test length(dimensional_space(u"m/m")) == 0
-        @test dimensional_space(u"m/km") == [Dimension{:Length}(1//1)]
-        @test dimensional_space(u"m/s") ==
+        @test @inferred(dimensional_space(u"m/km")) ==
+        	Dimension[Dimension{:Length}(1//1)]
+        @test @inferred(dimensional_space(u"m/s")) ==
             [Dimension{:Length}(1//1), Dimension{:Time}(1//1)]
         @test dimensional_space(u"m/s*J") ==
             [
@@ -16,9 +17,11 @@ using Unitful: dimensional_space, Dimensions, Dimension, dimensional_matrix,
                 Dimension{:Time}(1//1)
             ]
 
-        @test dimensional_space(u"m", u"km") == [Dimension{:Length}(1//1)]
-        @test dimensional_space(u"m", u"km/km") == [Dimension{:Length}(1//1)]
-        @test dimensional_space(u"m", u"m/s") ==
+        @test @inferred(dimensional_space(u"m", u"km")) ==
+ 			[Dimension{:Length}(1//1)]
+        @test @inferred(dimensional_space(u"m", u"km/km")) ==
+			[Dimension{:Length}(1//1)]
+        @test @inferred(dimensional_space(u"m", u"m/s")) ==
             [Dimension{:Length}(1//1), Dimension{:Time}(1//1)]
     end
 

--- a/test/vectorial.jl
+++ b/test/vectorial.jl
@@ -1,37 +1,39 @@
 using Base.Test
 using Unitful: dimensional_space, Dimensions, Dimension, dimensional_matrix,
     two_by_two_independant, independant_columns, project_on_basis, @u_str,
-    simplify
-@testset "Type simplification" begin
-    @testset "> Actual simplification" begin
-        @test simplify(u"cm") === u"cm"
-        @test simplify(2u"cm") === 2u"cm"
-        @test simplify(u"cm/m") == u"m/m"
-        @test simplify(1u"cm/m") == 1//100
-        @test simplify(2.4u"cm/m") == 2.4 * 1//100
-        @test simplify(u"m*m*km*J/cm") == u"J*cm^2"
-        @test simplify(1u"m*m*km*J/cm") == 1000000000//1 * u"J*cm^2"
-		@test 1u"m*m*km*J/cm" == 1000000000//1 * u"J*cm^2"
-		@test simplify(u"m*m*km*J/cm/N") == u"cm^3"
-		@test simplify(2u"m*m*km*J/cm/N") == 200000000000//1 *u"cm^3"
-		@test 1u"m*m*km*J/cm/N" == 100000000000//1 *u"cm^3"
-    end
+    simplify, dimensional_vector, SI
 
+@testset "Type simplification - implementation" begin
     @testset "> Count dimensions in a unit" begin
-        @test dimensional_space(u"m/m") === Dimensions{()}
-        @test dimensional_space(u"m/km") ===
-            Dimensions{(Dimension{:Length}(1//1),)}
-        @test dimensional_space(u"m/s") ===
-            Dimensions{(Dimension{:Length}(1//1), Dimension{:Time}(1//1))}
-        @test dimensional_space(u"m/s*J") ===
-            Dimensions{(
-                    Dimension{:Length}(1//1),
-                    Dimension{:Mass}(1//1),
-                    Dimension{:Time}(1//1)
-            )}
+        @test length(dimensional_space(u"m/m")) == 0
+        @test dimensional_space(u"m/km") == [Dimension{:Length}(1//1)]
+        @test dimensional_space(u"m/s") ==
+            [Dimension{:Length}(1//1), Dimension{:Time}(1//1)]
+        @test dimensional_space(u"m/s*J") ==
+            [
+                Dimension{:Length}(1//1),
+                Dimension{:Mass}(1//1),
+                Dimension{:Time}(1//1)
+            ]
+
+        @test dimensional_space(u"m", u"km") == [Dimension{:Length}(1//1)]
+        @test dimensional_space(u"m", u"km/km") == [Dimension{:Length}(1//1)]
+        @test dimensional_space(u"m", u"m/s") ==
+            [Dimension{:Length}(1//1), Dimension{:Time}(1//1)]
     end
 
-    @testset "> Transform unit to matrix format" begin
+    @testset "> Transform unit to vector format" begin
+		dspace = [
+			Unitful.Dimension{:Length}(1//1), Unitful.Dimension{:Mass}(1//1),
+			Unitful.Dimension{:Time}(1//1), Unitful.Dimension{:yolo}(1)
+        ]
+    	@test dimensional_vector(typeof(u"m*J").parameters[1][1], dspace) ==
+				[2//1, 1//1, -2//1, 0//1]
+		@test dimensional_vector(typeof(u"m*J"), dspace) ==
+				[3//1, 1//1, -2//1, 0//1]
+    end
+
+    @testset "> Transform units to matrix format" begin
         @test size(dimensional_matrix(u"m/m")) == (0, 0)
         @test dimensional_matrix(u"m/km") == [1//1 -1//1]
         @test dimensional_matrix(u"m/km*s") == [1//1 -1//1 0;0 0 1//1]
@@ -77,5 +79,56 @@ using Unitful: dimensional_space, Dimensions, Dimension, dimensional_matrix,
             @test sum(proj[i] * matrix[:, i] for i in 1:size(matrix, 2)) ≈
                 vector
         end
+    end
+end
+
+@testset "Type simplification - usage" begin
+	@testset "> No preferred units" begin
+		@test simplify(u"cm") === u"cm"
+		@test simplify(2u"cm") === 2u"cm"
+		@test simplify(u"cm/m") == u"m/m"
+		@test simplify(1u"cm/m") == 1//100
+		@test simplify(2.4u"cm/m") == 2.4 * 1//100
+		@test simplify(u"m*m*km*J/cm") == u"J*cm^2"
+		@test simplify(1u"m*m*km*J/cm") == 1000000000//1 * u"J*cm^2"
+		@test 1u"m*m*km*J/cm" == 1000000000//1 * u"J*cm^2"
+		@test simplify(u"m*m*km*J/cm/N") == u"cm^3"
+		@test simplify(2u"m*m*km*J/cm/N") == 200000000000//1 *u"cm^3"
+		@test 1u"m*m*km*J/cm/N" == 100000000000//1 *u"cm^3"
+	end
+
+	@testset "With preferred units" begin
+		@test simplify(u"cm", Unitful.Units[u"cm"]) === u"cm"
+		@test simplify(u"cm", Unitful.Units[u"m"]) === u"m"
+		@test simplify(u"cm", Unitful.Units[u"m", u"km"]) === u"m"
+		@test simplify(u"cm", Unitful.Units[u"m^-1"]) === u"m"
+		@test simplify(u"s", Unitful.Units[u"Hz"]) === u"Hz^-1"
+		@test simplify(u"s", Unitful.Units[u"m"]) === u"s"
+		@test simplify(u"J", Unitful.Units[u"Hz"]) === u"J"
+		@test simplify(u"J", Unitful.Units[u"Hz", u"J"]) === u"J"
+		@test simplify(u"J", Unitful.Units[u"Hz", u"nm", u"kg"]) ===
+			u"kg*Hz^2*nm^2"
+
+        # missing u"s", so u"J" is the only one that matches
+		@test simplify(u"J", Unitful.Units[u"Hz", u"nm", u"J"]) === u"J"
+		# J gets eliminated when creating basis for input unit, since it is not
+        # linearly independent from the others.
+		# Actually, the input unit is always added at the end of the preferred
+        # units, so adding it again explicitly is unnecessary.
+		@test simplify(u"J", Unitful.Units[u"Hz", u"nm", u"kg", u"J"]) ===
+			u"kg*Hz^2*nm^2"
+		# Here, however u"J" comes first, so some other unit gets squashed when
+        # creating the basis of units.
+		@test simplify(u"J", Unitful.Units[u"J", u"Hz", u"nm", u"kg"]) === u"J"
+		@test simplify(u"J", Unitful.Units[u"Hz", u"J", u"nm", u"kg"]) === u"J"
+
+        @test simplify(u"J", Unitful.Units[u"N", u"m"]) === u"m * N"
+		@test simplify(u"J*N", Unitful.Units[u"N", u"m"]) === u"m * N^2"
+
+		@test simplify(1u"J*N", Unitful.Units[u"N", u"m"]) == 1u"m * N^2"
+		@test simplify(1u"J*N", Unitful.Units[u"N", u"cm"]) == 100u"cm * N^2"
+		@test simplify(1u"J*N", (u"N", u"cm")) == 100u"cm * N^2"
+		@test simplify(u"J*N", SI) === u"kg^2*m^3*s^-4"
+		@test simplify(1u"J*N", SI) == 1u"J*N"
     end
 end


### PR DESCRIPTION
This  pull request is far from complete. If anything, it requires some more unit-testing. But I would appreciate some thoughts on whether it could eventually make it. The main problem, as I see it, is that I have to use a non-exact algorithm to project onto a non-orthogonal set of basis vector, each vector being a unit.

Usage is given in the docstring for `simplify`.

The simplification proceeds by:
1. figuring out a minimal set of linearly independent units from the input quantity/units. The set of units are chosen to have the smallest possible dimensions at this stage.
2. projecting the input units onto this minimal set units. The set can be non-orthogonal, so the projection takes place via a iterating projection algorithm. It is not an exact algorithm, so some rounding is done at the end. In most cases, I would expect this is sufficient to recover the exact projection.
3. conversion to the new units using `uconvert`

The main problem is figuring out how to project onto a non-orthogonal
basis. There are probably other (better?) ways of doing this.

Another issue is how to figure out some heuristics to choose the linearly
independent units. We could try and add conditions to favor SI units, and/or
units with the smallest prefix (as in smallest abs(log10(prefix))), and/or
even the units with the smallest screen foot-print when dumping to STDOUT.
