### PR TITLE
Allow inversion of unitful matrices

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -559,6 +559,15 @@ end
     :($y)
 end
 
+function inv{T <: Quantity}(x::Matrix{T})
+    length(x) > 0 &&
+        any(dimension(x[1, 1]) .!= collect(dimension(u) for u in x)) &&
+        error("Matrix must have consistent dimensions to perform inversion")
+    # make sure that matrix we will invert has consistent units
+    # only then can we invert the underlying matrix
+    inv(ustrip(convert(Matrix{typeof(x[1])}, x))) * inv(unit(x[1]))
+end
+
 ^{T}(x::Unit{T}, y::Integer) = Unit{T}(tens(x),power(x)*y)
 ^{T}(x::Unit{T}, y) = Unit{T}(tens(x),power(x)*y)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -264,6 +264,10 @@ end
         @test @inferred(atan2(m*sqrt(3),1m)) ≈ 60°
     end
 
+    @testset "> Matrix inversion" begin
+        @test inv([1 1; -1 1]u"nm") ≈ [0.5 -0.5; 0.5 0.5]u"nm^-1"
+    end
+
     @testset "> Is functions" begin
         @test isinteger(1.0m)
         @test !isinteger(1.4m)


### PR DESCRIPTION
At least in some cases, the pivot step in the matrix inversion requires
scaling one coefficient by another. However this fails when implemented
in terms of two operations: first an inversion which gives an object
with an inverse unit (rather than a dimensionless quantity), then a
`*=` multiplication. The second step tries (incorrectly) to change the
dimension of the matrix coefficient to dimensionless.

The relevant lines in `linalg/lu.jl` are:

```Julia
Akkinv = inv(A[k,k])
for i = k+1:m
    A[i,k] *= Akkinv
end
```

This commit hacks an `inv` function for the relevant matrices that first
strips the units from the matrix.