### PR TITLE
Remove remaining `mod`.

### DIFF
--- a/src/fastmath.jl
+++ b/src/fastmath.jl
@@ -151,7 +151,7 @@ le_fast{T<:FloatTypes,D,U}(x::Quantity{T,D,U}, y::Quantity{T,D,U}) =
     ne_fast{T<:ComplexTypes,D,U}(x::Quantity{T,D,U}, y::Quantity{T,D,U}) = !(x==y)
 end
 
-for op in (:+, :-, :*, :/, :(==), :!=, :<, :<=, :cmp, :mod, :rem)
+for op in (:+, :-, :*, :/, :(==), :!=, :<, :<=, :cmp, :rem)
     op_fast = fast_op[op]
     @eval begin
         # Fallback method for Quantitys after promotion.


### PR DESCRIPTION
One last reference to `mod_fast` slipped through and broke precompilation, like this:

```julia
julia> using Unitful
INFO: Precompiling module Unitful.
ERROR: LoadError: LoadError: KeyError: key :mod not found
Stacktrace:
 [1] getindex at ./dict.jl:474 [inlined]
 [2] macro expansion at /Users/helge/.julia/v0.6/Unitful/src/fastmath.jl:155 [inlined]
 [3] anonymous at ./<missing>:?
 [4] include_from_node1(::String) at ./loading.jl:539
 [5] include(::String) at ./sysimg.jl:14
 [6] include_from_node1(::String) at ./loading.jl:539
 [7] include(::String) at ./sysimg.jl:14
 [8] anonymous at ./<missing>:2
while loading /Users/helge/.julia/v0.6/Unitful/src/fastmath.jl, in expression starting on line 154
while loading /Users/helge/.julia/v0.6/Unitful/src/Unitful.jl, in expression starting on line 1071
ERROR: Failed to precompile Unitful to /Users/helge/.julia/lib/v0.6/Unitful.ji.
Stacktrace:
 [1] compilecache(::String) at ./loading.jl:673
 [2] require(::Symbol) at ./loading.jl:460
```