### PR TITLE
readable DimensionError message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
+- v0.1.5
+ - Patch for Julia PR [#20889](https://github.com/JuliaLang/julia/pull/20889), which changes
+   how lowering is done for exponentiation of integer literals.
+
 - v0.1.4
  - Critical bug fix owing to `mod_fast` changes.
- 
+
 - v0.1.3
  - Fix symmetry of `==` [#56](https://github.com/ajkeller34/Unitful.jl/issues/56).
  - Using `@refunit` will implicitly specify the ref. unit as the default for promotion.
@@ -8,7 +12,7 @@
    fail for quantities with user-defined dimensions.
  - Remove `mod_fast` in anticipation of Julia PR [#20859](https://github.com/JuliaLang/julia/pull/20859).
  - Allow tolerance args for `isapprox` [#57](https://github.com/ajkeller34/Unitful.jl/pull/57)
- 
+
 - v0.1.2
  - On Julia 0.6, exponentiation by a literal is now type stable for integers.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 - v0.1.5
   - Patch for Julia PR [#20889](https://github.com/JuliaLang/julia/pull/20889), which changes how lowering is done for exponentiation of integer literals.
   - Bug fix to enable registering Main as a module for `u_str` (fixes [#61](https://github.com/ajkeller34/Unitful.jl/issues/61)).
+  - Implement readable message for `DimensionError` [#62](https://github.com/ajkeller34/Unitful.jl/pull/62).
 - v0.1.4
   - Critical bug fix owing to `mod_fast` changes.
 - v0.1.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,6 @@
 - v0.1.5
-  - Patch for Julia PR [#20889](https://github.com/JuliaLang/julia/pull/20889), which changes
-   how lowering is done for exponentiation of integer literals.
-  - Bug fix to enable registering Main as a module for `u_str` (fixes 
-    [#61](https://github.com/ajkeller34/Unitful.jl/issues/61)).
+  - Patch for Julia PR [#20889](https://github.com/JuliaLang/julia/pull/20889), which changes how lowering is done for exponentiation of integer literals.
+  - Bug fix to enable registering Main as a module for `u_str` (fixes [#61](https://github.com/ajkeller34/Unitful.jl/issues/61)).
 - v0.1.4
   - Critical bug fix owing to `mod_fast` changes.
 - v0.1.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,10 @@
 - v0.1.5
   - Patch for Julia PR [#20889](https://github.com/JuliaLang/julia/pull/20889), which changes
    how lowering is done for exponentiation of integer literals.
-  - Bug fix to enable registering Main as a module for `u_str`.
-
+  - Bug fix to enable registering Main as a module for `u_str` (fixes 
+    [#61](https://github.com/ajkeller34/Unitful.jl/issues/61)).
 - v0.1.4
   - Critical bug fix owing to `mod_fast` changes.
-
 - v0.1.3
   - Fix symmetry of `==` [#56](https://github.com/ajkeller34/Unitful.jl/issues/56).
   - Using `@refunit` will implicitly specify the ref. unit as the default for promotion.
@@ -13,14 +12,11 @@
     fail for quantities with user-defined dimensions.
   - Remove `mod_fast` in anticipation of Julia PR [#20859](https://github.com/JuliaLang/julia/pull/20859).
   - Allow tolerance args for `isapprox` [#57](https://github.com/ajkeller34/Unitful.jl/pull/57)
-
 - v0.1.2
   - On Julia 0.6, exponentiation by a literal is now type stable for integers.
-
 - v0.1.1
   - Fixed a macro hygiene issue that prevented `@dimension` and `@derived_dimension`
    from working properly if Compat was not imported in the calling namespace.
-
 - v0.1.0
   - Julia 0.6 compatibility.
   - On Julia 0.6, exponentiation by a literal is now type stable for
@@ -47,7 +43,6 @@
   - Added `istriu`, `istril` for `AbstractMatrix{T<:Quantity}`.
   - The `Unitful.SIUnits` module has been renamed to `Unitful.DefaultSymbols`.
   - Add `lb`, `oz`, `dr`, `gr` to Unitful (international Avoirdupois mass units).
-
 - v0.0.4
   - Be aware, breaking changes to `deps/Defaults.jl` caused by some of the following!
   - Fix [#40](https://github.com/ajkeller34/Unitful.jl/issues/40).
@@ -77,7 +72,6 @@
     (some logic moved out of defaults).
   - Moved definition of `sin`, `cos`, `tan`, `sec`, `csc`, `cot` out of
     `deps/build.jl` and into `src/Unitful.jl`.
-
 - v0.0.3
   - Bug fix: `uconvert(°C, 0x01°C)` no longer disturbs the numeric type
   - Allow μ-prefixed units to be typed with option-m on a Mac, in addition to
@@ -96,22 +90,12 @@
     also be true if you mixed unitless and unitful numbers during promotion, but
     that is not yet the case. See [#24](https://github.com/ajkeller34/Unitful.jl/issues/24)
     for motivation.
-
-
 - v0.0.2
   - Bug fixes (`[1.0m, 2.0m] ./ 3` would throw a `Unitful.DimensionError()`).
     Promotion still isn't perfect, but it is hard for me to see what `@inferred`
     errors are real until https://github.com/JuliaLang/julia/issues/18465 is resolved.
- 
-  - Made units callable for unit conversion:
-    ```
-    u"cm"(1u"m") == 100u"cm"//1
-```
+  - Made units callable for unit conversion: `u"cm"(1u"m") == 100u"cm"//1`.
     Note that `Units` objects have no fields, so this is totally unambiguous.
     Moreover, we have convenient syntax for unit conversion by function chaining:
-    ```
-    1u"m" |> u"cm" == 100u"cm"//1
-```
-    Note that `uconvert` will remain supported.
-
+    `1u"m" |> u"cm" == 100u"cm"//1`. Note that `uconvert` will remain supported.
 - v0.0.1 - Initial release

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,117 +1,116 @@
 - v0.1.5
- - Patch for Julia PR [#20889](https://github.com/JuliaLang/julia/pull/20889), which changes
+  - Patch for Julia PR [#20889](https://github.com/JuliaLang/julia/pull/20889), which changes
    how lowering is done for exponentiation of integer literals.
- - Bug fix to enable registering Main as a module for `u_str`.
+  - Bug fix to enable registering Main as a module for `u_str`.
 
 - v0.1.4
- - Critical bug fix owing to `mod_fast` changes.
+  - Critical bug fix owing to `mod_fast` changes.
 
 - v0.1.3
- - Fix symmetry of `==` [#56](https://github.com/ajkeller34/Unitful.jl/issues/56).
- - Using `@refunit` will implicitly specify the ref. unit as the default for promotion.
-   This will not change behavior for most people; it just ensures promotion won't
-   fail for quantities with user-defined dimensions.
- - Remove `mod_fast` in anticipation of Julia PR [#20859](https://github.com/JuliaLang/julia/pull/20859).
- - Allow tolerance args for `isapprox` [#57](https://github.com/ajkeller34/Unitful.jl/pull/57)
+  - Fix symmetry of `==` [#56](https://github.com/ajkeller34/Unitful.jl/issues/56).
+  - Using `@refunit` will implicitly specify the ref. unit as the default for promotion.
+    This will not change behavior for most people; it just ensures promotion won't
+    fail for quantities with user-defined dimensions.
+  - Remove `mod_fast` in anticipation of Julia PR [#20859](https://github.com/JuliaLang/julia/pull/20859).
+  - Allow tolerance args for `isapprox` [#57](https://github.com/ajkeller34/Unitful.jl/pull/57)
 
 - v0.1.2
- - On Julia 0.6, exponentiation by a literal is now type stable for integers.
+  - On Julia 0.6, exponentiation by a literal is now type stable for integers.
 
 - v0.1.1
- - Fixed a macro hygiene issue that prevented `@dimension` and `@derived_dimension`
+  - Fixed a macro hygiene issue that prevented `@dimension` and `@derived_dimension`
    from working properly if Compat was not imported in the calling namespace.
 
 - v0.1.0
- - Julia 0.6 compatibility.
- - On Julia 0.6, exponentiation by a literal is now type stable for
-   common integer powers: -3, -2, -1, 0, 1, 2, 3.
- - Added missing methods for dot operators `.<` and `.<=` (Julia 0.5, fix
-   [#55](https://github.com/ajkeller34/Unitful.jl/issues/55)).
- - Fix [#45](https://github.com/ajkeller34/Unitful.jl/issues/45). Ranges should
-   work as expected on Julia 0.6. On Julia 0.5, [Ranges.jl](https://github.com/JuliaArrays/Ranges.jl)
-   is used to make ranges work as well as possible given limitations in Base.
- - Fix [#33](https://github.com/ajkeller34/Unitful.jl/issues/33),
-   [#42](https://github.com/ajkeller34/Unitful.jl/issues/42),
-   and [#50](https://github.com/ajkeller34/Unitful.jl/issues/50).
-   `deps/Defaults.jl` is dead. Long live `deps/Defaults.jl`. To define your own
-   units, dimensions, and so on, you should now put them in a module, or ideally
-   a package so that others can use the definitions too. You can override default
-   promotion rules immediately after loading Unitful and dependent packages; this
-   will generate method overwrite warnings on Julia 0.5 but not on 0.6.
- - `@u_str` macro has been improved. It can now traverse separate unit packages,
-   as well as return tuples of `Units` objects.
- - `@preferunit` has been replaced with a function `preferunits`.
- - Added some methods for `ustrip`.
- - Implement `typemin`, `typemax`, `cbrt` for `Quantity`s.
- - Added matrix inversion for `StridedMatrix{T<:Quantity}`.
- - Added `istriu`, `istril` for `AbstractMatrix{T<:Quantity}`.
- - The `Unitful.SIUnits` module has been renamed to `Unitful.DefaultSymbols`.
- - Add `lb`, `oz`, `dr`, `gr` to Unitful (international Avoirdupois mass units).
-
+  - Julia 0.6 compatibility.
+  - On Julia 0.6, exponentiation by a literal is now type stable for
+    common integer powers: -3, -2, -1, 0, 1, 2, 3.
+  - Added missing methods for dot operators `.<` and `.<=` (Julia 0.5, fix
+    [#55](https://github.com/ajkeller34/Unitful.jl/issues/55)).
+  - Fix [#45](https://github.com/ajkeller34/Unitful.jl/issues/45). Ranges should
+    work as expected on Julia 0.6. On Julia 0.5, [Ranges.jl](https://github.com/JuliaArrays/Ranges.jl)
+    is used to make ranges work as well as possible given limitations in Base.
+  - Fix [#33](https://github.com/ajkeller34/Unitful.jl/issues/33),
+    [#42](https://github.com/ajkeller34/Unitful.jl/issues/42),
+    and [#50](https://github.com/ajkeller34/Unitful.jl/issues/50).
+    `deps/Defaults.jl` is dead. Long live `deps/Defaults.jl`. To define your own
+    units, dimensions, and so on, you should now put them in a module, or ideally
+    a package so that others can use the definitions too. You can override default
+    promotion rules immediately after loading Unitful and dependent packages; this
+    will generate method overwrite warnings on Julia 0.5 but not on 0.6.
+  - `@u_str` macro has been improved. It can now traverse separate unit packages,
+    as well as return tuples of `Units` objects.
+  - `@preferunit` has been replaced with a function `preferunits`.
+  - Added some methods for `ustrip`.
+  - Implement `typemin`, `typemax`, `cbrt` for `Quantity`s.
+  - Added matrix inversion for `StridedMatrix{T<:Quantity}`.
+  - Added `istriu`, `istril` for `AbstractMatrix{T<:Quantity}`.
+  - The `Unitful.SIUnits` module has been renamed to `Unitful.DefaultSymbols`.
+  - Add `lb`, `oz`, `dr`, `gr` to Unitful (international Avoirdupois mass units).
 
 - v0.0.4
- - Be aware, breaking changes to `deps/Defaults.jl` caused by some of the following!
- - Fix [#40](https://github.com/ajkeller34/Unitful.jl/issues/40).
- - Fix [#30](https://github.com/ajkeller34/Unitful.jl/issues/30).
- - Support relevant `@fastmath` operations for `Quantity`s.
- - Implement `fma`, `atan2` for `Quantity`s.
- - Implement `cis` for dimensionless `Quantity`s.
- - Removed `DimensionedUnits` and `DimensionedQuantity` abstract types.
-   They were of dubious utility, and this change shortened the promotion code
-   considerably. More importantly, this change has made it possible to write
-   methods like the following, without method ambiguities:
-   `uconvert(e::EnergyUnit, f::Frequency) = uconvert(e, u"h"*f)`.
- - Promotion wraps usual `Number` types in dimensionless, unitless `Quantity`
-   types when promoted together with dimensionful `Quantity`s.
-   With `Quantity`s it is not always possible to promote to a common
-   concrete type, but this way we can at least ensure that the numeric backing
-   types are all promoted: (`promote(1.0u"m", 1u"N"//2, 0x08) == (1.0 m,0.5 N,8.0)`,
-   where `8.0` is actually a dimensionless, unitless `Quantity`).
-   The usual outer constructor for `Quantity`s (`Quantity(val::T, unit)`)
-   continues to return a number of type `T` if the unit is `NoUnits`,
-   since most of the time the user would prefer a `Number` type from base rather
-   than a dimensionless, unitless quantity.
- - Add more units to defaults: `bar` (bar), `Torr` (torr), `atm` (atmosphere),
-   `l` or `L` (liter; both symbols accepted). You will need to delete
-   `deps/Defaults.jl` in the Unitful package directory to get the new units.
- - Two character encodings for `μ` in SI prefixes are now generated automatically
-   (some logic moved out of defaults).
- - Moved definition of `sin`, `cos`, `tan`, `sec`, `csc`, `cot` out of
-   `deps/build.jl` and into `src/Unitful.jl`.
+  - Be aware, breaking changes to `deps/Defaults.jl` caused by some of the following!
+  - Fix [#40](https://github.com/ajkeller34/Unitful.jl/issues/40).
+  - Fix [#30](https://github.com/ajkeller34/Unitful.jl/issues/30).
+  - Support relevant `@fastmath` operations for `Quantity`s.
+  - Implement `fma`, `atan2` for `Quantity`s.
+  - Implement `cis` for dimensionless `Quantity`s.
+  - Removed `DimensionedUnits` and `DimensionedQuantity` abstract types.
+    They were of dubious utility, and this change shortened the promotion code
+    considerably. More importantly, this change has made it possible to write
+    methods like the following, without method ambiguities:
+    `uconvert(e::EnergyUnit, f::Frequency) = uconvert(e, u"h"*f)`.
+  - Promotion wraps usual `Number` types in dimensionless, unitless `Quantity`
+    types when promoted together with dimensionful `Quantity`s.
+    With `Quantity`s it is not always possible to promote to a common
+    concrete type, but this way we can at least ensure that the numeric backing
+    types are all promoted: (`promote(1.0u"m", 1u"N"//2, 0x08) == (1.0 m,0.5 N,8.0)`,
+    where `8.0` is actually a dimensionless, unitless `Quantity`).
+    The usual outer constructor for `Quantity`s (`Quantity(val::T, unit)`)
+    continues to return a number of type `T` if the unit is `NoUnits`,
+    since most of the time the user would prefer a `Number` type from base rather
+    than a dimensionless, unitless quantity.
+  - Add more units to defaults: `bar` (bar), `Torr` (torr), `atm` (atmosphere),
+    `l` or `L` (liter; both symbols accepted). You will need to delete
+    `deps/Defaults.jl` in the Unitful package directory to get the new units.
+  - Two character encodings for `μ` in SI prefixes are now generated automatically
+    (some logic moved out of defaults).
+  - Moved definition of `sin`, `cos`, `tan`, `sec`, `csc`, `cot` out of
+    `deps/build.jl` and into `src/Unitful.jl`.
 
 - v0.0.3
- - Bug fix: `uconvert(°C, 0x01°C)` no longer disturbs the numeric type
- - Allow μ-prefixed units to be typed with option-m on a Mac, in addition to
-   using Unicode. Previously only `μm` could be typed this way.
- - Include a `baremodule` called `SIUnits` in the factory defaults. You can
-   now do `using Unitful.SIUnits` to bring all of the SI units into the calling
-   namespace.
- - Added remaining SI units to the factory defaults: `sr` (steradian), `lm`
-   (luminous flux), `lx` (illuminance), `Bq` (becquerel), `Gy` (gray),
-   `Sv` (sievert), `kat` (katal).
- - Simplify array creation, as in `[1, 2]u"km"` [#29](https://github.com/ajkeller34/Unitful.jl/pull/29)
- - Support multiplying ranges by units, as in `(1:3)*mm` [#28](https://github.com/ajkeller34/Unitful.jl/pull/28)
- - Bug fix [#26](https://github.com/ajkeller34/Unitful.jl/issues/26)
- - Promoting `Quantity`s with different dimensions now returns quantities with
-   the same numeric backing type, e.g. `Quantity{Float64}`. Ideally, this would
-   also be true if you mixed unitless and unitful numbers during promotion, but
-   that is not yet the case. See [#24](https://github.com/ajkeller34/Unitful.jl/issues/24)
-   for motivation.
+  - Bug fix: `uconvert(°C, 0x01°C)` no longer disturbs the numeric type
+  - Allow μ-prefixed units to be typed with option-m on a Mac, in addition to
+    using Unicode. Previously only `μm` could be typed this way.
+  - Include a `baremodule` called `SIUnits` in the factory defaults. You can
+    now do `using Unitful.SIUnits` to bring all of the SI units into the calling
+    namespace.
+  - Added remaining SI units to the factory defaults: `sr` (steradian), `lm`
+    (luminous flux), `lx` (illuminance), `Bq` (becquerel), `Gy` (gray),
+    `Sv` (sievert), `kat` (katal).
+  - Simplify array creation, as in `[1, 2]u"km"` [#29](https://github.com/ajkeller34/Unitful.jl/pull/29)
+  - Support multiplying ranges by units, as in `(1:3)*mm` [#28](https://github.com/ajkeller34/Unitful.jl/pull/28)
+  - Bug fix [#26](https://github.com/ajkeller34/Unitful.jl/issues/26)
+  - Promoting `Quantity`s with different dimensions now returns quantities with
+    the same numeric backing type, e.g. `Quantity{Float64}`. Ideally, this would
+    also be true if you mixed unitless and unitful numbers during promotion, but
+    that is not yet the case. See [#24](https://github.com/ajkeller34/Unitful.jl/issues/24)
+    for motivation.
 
 
 - v0.0.2
- - Bug fixes (`[1.0m, 2.0m] ./ 3` would throw a `Unitful.DimensionError()`).
-Promotion still isn't perfect, but it is hard for me to see what `@inferred`
-errors are real until https://github.com/JuliaLang/julia/issues/18465 is resolved.
-
- - Made units callable for unit conversion:
+  - Bug fixes (`[1.0m, 2.0m] ./ 3` would throw a `Unitful.DimensionError()`).
+    Promotion still isn't perfect, but it is hard for me to see what `@inferred`
+    errors are real until https://github.com/JuliaLang/julia/issues/18465 is resolved.
+ 
+  - Made units callable for unit conversion:
     ```
-u"cm"(1u"m") == 100u"cm"//1
+    u"cm"(1u"m") == 100u"cm"//1
 ```
     Note that `Units` objects have no fields, so this is totally unambiguous.
-Moreover, we have convenient syntax for unit conversion by function chaining:
-     ```
-1u"m" |> u"cm" == 100u"cm"//1
+    Moreover, we have convenient syntax for unit conversion by function chaining:
+    ```
+    1u"m" |> u"cm" == 100u"cm"//1
 ```
     Note that `uconvert` will remain supported.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 - v0.1.5
  - Patch for Julia PR [#20889](https://github.com/JuliaLang/julia/pull/20889), which changes
    how lowering is done for exponentiation of integer literals.
+ - Bug fix to enable registering Main as a module for `u_str`.
 
 - v0.1.4
  - Critical bug fix owing to `mod_fast` changes.

--- a/src/Conversion.jl
+++ b/src/Conversion.jl
@@ -29,7 +29,7 @@ function uconvert(a::Units, x::Number)
     if dimension(a) == NoDims
         Quantity(x * convfact(a, NoUnits), a)
     else
-        throw(DimensionError())
+        throw(DimensionError(a,x))
     end
 end
 
@@ -47,7 +47,7 @@ Find the conversion factor from unit `t` to unit `s`, e.g. `convfact(m,cm) = 0.0
     # Check if conversion is possible in principle
     sdim = dimension(s())
     tdim = dimension(t())
-    sdim != tdim && throw(DimensionError())
+    sdim != tdim && throw(DimensionError(s,t))
 
     # first convert to base SI units.
     # fact1 is what would need to be multiplied to get to base SI units
@@ -133,7 +133,7 @@ function convert{T,D,U}(::Type{Quantity{T,D,U}}, x::Number)
     if dimension(x) == D()
         Quantity(T(uconvert(U(),x).val), U())
     else
-        throw(DimensionError())
+        throw(DimensionError(U(),x))
     end
 end
 
@@ -179,7 +179,7 @@ function convert{T,U}(::Type{DimensionlessQuantity{T,U}}, x::Quantity)
     if dimension(x) == NoDims
         Quantity(T(x.val), U())
     else
-        throw(DimensionError())
+        throw(DimensionError(NoDims,x))
     end
 end
 

--- a/src/Conversion.jl
+++ b/src/Conversion.jl
@@ -47,7 +47,7 @@ Find the conversion factor from unit `t` to unit `s`, e.g. `convfact(m,cm) = 0.0
     # Check if conversion is possible in principle
     sdim = dimension(s())
     tdim = dimension(t())
-    sdim != tdim && throw(DimensionError(s,t))
+    sdim != tdim && throw(DimensionError(s(),t()))
 
     # first convert to base SI units.
     # fact1 is what would need to be multiplied to get to base SI units

--- a/src/Promotion.jl
+++ b/src/Promotion.jl
@@ -7,7 +7,7 @@
             if dimension(S())==dimension(T())
                 promote_type(S,T)
             else
-                throw(DimensionError())
+                throw(DimensionError(S(),T()))
             end
         end
     end
@@ -18,7 +18,7 @@
             if dimension(S())==dimension(T())
                 promote_type(S,T)
             else
-                throw(DimensionError())
+                throw(DimensionError(S(),T()))
             end
         end
     end
@@ -35,7 +35,7 @@
         ::Type{Quantity{T1,D1,U1}}, ::Type{Quantity{T2,D2,U2}})
         # figuring out numeric type can be subtle if D1 == D2 but U1 != U2.
         # in particular, consider adding 1m + 1cm... the numtype is not Int.
-        D1 != D2 && throw(DimensionError())
+        D1 != D2 && throw(DimensionError(U1(),U2()))
         return Bool
     end
     function promote_op{T1,D1,U1,T2,D2,U2}(op, x::Type{Quantity{T1,D1,U1}},
@@ -62,7 +62,7 @@
         ::Type{R}, ::Type{Quantity{S,D,U}})
         # figuring out numeric type can be subtle if D1 == D2 but U1 != U2.
         # in particular, consider adding 1m + 1cm... the numtype is not Int.
-        D != Dimensions{()} && throw(DimensionError())
+        D != Dimensions{()} && throw(DimensionError(NoDims,U()))
         return Bool
     end
     function promote_op{R<:Number,S,D,U}(op, ::Type{R}, ::Type{Quantity{S,D,U}})
@@ -86,7 +86,7 @@
         ::Type{Quantity{S,D,U}}, ::Type{R})
         # figuring out numeric type can be subtle if D1 == D2 but U1 != U2.
         # in particular, consider adding 1m + 1cm... the numtype is not Int.
-        D != Dimensions{()} && throw(DimensionError())
+        D != Dimensions{()} && throw(DimensionError(NoDims,U()))
         return Bool
     end
     function promote_op{R<:Number,S,D,U}(op, x::Type{Quantity{S,D,U}}, y::Type{R})

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -54,13 +54,16 @@ type DimensionError{T,S} <: Exception
   y::S
 end
 ```
-Thrown when dimensions don't match in an operation that demands they do. Display `x` and `y` in error message.
+
+Thrown when dimensions don't match in an operation that demands they do.
+Display `x` and `y` in error message.
 """
 type DimensionError{T,S} <: Exception
-  x::T
-  y::S
+    x::T
+    y::S
 end
-Base.showerror(io::IO, e::DimensionError) = print(io,"DimensionError: $(e.x) and $(e.y) are not dimensionally compatible.");
+Base.showerror(io::IO, e::DimensionError) =
+    print(io,"DimensionError: $(e.x) and $(e.y) are not dimensionally compatible.");
 
 """
 ```

--- a/src/User.jl
+++ b/src/User.jl
@@ -373,6 +373,7 @@ end
 
 dottify(s, t, u...) = dottify(Expr(:(.), s, QuoteNode(t)), u...)
 dottify(s) = s
+dottify() = Main        # needed because fullname(Main) == (). TODO: How to test?
 
 function replace_value(sym::Symbol)
     where = [isdefined(unitmodules[i], sym) for i in eachindex(unitmodules)]

--- a/src/range.jl
+++ b/src/range.jl
@@ -10,18 +10,18 @@
     linspace(Float64, ustrip(start), ustrip(stop), len, 1)*unit(T)
 
 function _linspace{T}(start::Quantity{T}, stop::Quantity{T}, len::Integer)
-    dimension(start) != dimension(stop) && throw(DimensionError())
+    dimension(start) != dimension(stop) && throw(DimensionError(start, stop))
     linspace(start, stop, len)
 end
 
 @compat function colon(start::Quantity{<:Real}, step, stop::Quantity{<:Real})
-    dimension(start) != dimension(stop) && throw(DimensionError())
+    dimension(start) != dimension(stop) && throw(DimensionError(start, stop))
     T = promote_type(typeof(start),typeof(stop))
     return colon(convert(T,start), step, convert(T,stop))
 end
 
 function colon(start::A, step::B, stop::A) where A<:Quantity{<:Real} where B<:Quantity{<:Real}
-    dimension(start) != dimension(step) && throw(DimensionError())
+    dimension(start) != dimension(step) && throw(DimensionError(start, step))
     colon(promote(start, step, stop)...)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -839,6 +839,17 @@ end
     end
 end
 
+@testset "DimensionError message" begin
+  function errorstr(e)
+    b = IOBuffer()
+    Base.showerror(b,e)
+    String(b)
+  end
+  @test errorstr(DimensionError(1u"m",2)) == "DimensionError: 1 m and 2 are not dimensionally compatible."
+  @test errorstr(DimensionError(1u"m",NoDims)) == "DimensionError: 1 m and  are not dimensionally compatible."
+  @test errorstr(DimensionError(u"m",2)) == "DimensionError: m and 2 are not dimensionally compatible."
+end
+
 # Test that the @u_str macro will find units in other modules.
 module ShadowUnits
     using Unitful


### PR DESCRIPTION
It's hard to read the types of long units, so I put a more readable message in for DimensionError. With this PR
```
julia> 1u"m"+1u"s"
ERROR: DimensionError: 1 m and 1 s are not dimensionally compatible.
 in +(::Unitful.Quantity{Int64,Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)},Unitful.Units{(Unitful.Unit{:Meter,Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}}(0,1//1),),Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}}}, ::Unitful.Quantity{Int64,Unitful.Dimensions{(Unitful.Dimension{:Time}(1//1),)},Unitful.Units{(Unitful.Unit{:Second,Unitful.Dimensions{(Unitful.Dimension{:Time}(1//1),)}}(0,1//1),),Unitful.Dimensions{(Unitful.Dimension{:Time}(1//1),)}}}) at /Users/oneilg/.julia/v0.5/Unitful/src/Unitful.jl:412
```

I'd suggest a reading over Conversion.jl and Promotion.jl fairly close, as I had few decisions about what to do with ::Type arguments, and you may prefer something else.