### PR TITLE
Issue 79

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -466,12 +466,21 @@ function try_convert{T <: Integer}(::Type{T}, a::Rational)
         try_convert(Rational{T}, a)
     end
 end
+""" Converts to the first preferred type """
+function try_convert(T0::Type, T1::Type, T2::Type, a::Union{Integer, Rational})
+    r0 = try_convert(T0, a)
+    (typeof(r0) == T0 || typeof(r0) == Rational{T0}) && return r0
+    r1 = try_convert(T1, a)
+    (typeof(r1) == T1 || typeof(r0) == Rational{T1}) && return r1
+    try_convert(T2, a)
+end
 
 function basefactor{U}(x::Units{U})
     fact1 = map(basefactor, U)
     inex1 = mapreduce(x->getfield(x,1), *, 1.0, fact1)
-    ex1   = mapreduce(x->getfield(x,2), *, Int128(1)//1, fact1)
-    inex1, try_convert(length(fact1) > 0 ? typeof(fact1[1][2]): Int64, ex1)
+    ex1   = mapreduce(x->getfield(x,2), *, BigInt(1)//1, fact1)
+    T = length(fact1) > 0 ? typeof(fact1[1][2]): Int64
+    inex1, try_convert((T <: Rational ? T.parameters[1]: T), Int64, Int128, ex1)
 end
 
 # Addition / subtraction

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1110,6 +1110,7 @@ end
     expected = BigInt(Unitful.basefactor(Unitful.c)[2])^2 *
                BigInt(Unitful.basefactor(unit(Unitful.μ0))[2])
     @test Unitful.basefactor(unit(Unitful.μ0 * 1Unitful.c^2))[2] == expected
+    @test typeof(Unitful.basefactor(unit(Unitful.μ0 * 1Unitful.c^2))[2]) == Int128
     @test_approx_eq_eps upreferred(1u"ϵ0") 8.854187817e-12u"F*m^-1" 1e-20u"F*m^-1"
 end
 


### PR DESCRIPTION
To avoid overflows, the basefactor computations are done using BigInt.
The result are down casted to the basefactor of the first unit, Int64, or Int128, where possible.

This means basefactor is no longuer type stable. However, this should only affect compilation times since it is used only in generated functions, I think... 

Closes #79 