### PR TITLE
Define *(::TwicePrecision, ::Quantity)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/range.jl
+++ b/src/range.jl
@@ -44,6 +44,7 @@ _colon{T}(::Any, ::Any, start::T, step, stop::T) =
 
 # Opt into TwicePrecision functionality
 *(x::Base.TwicePrecision, y::Units) = Base.TwicePrecision(x.hi*y, x.lo*y)
+*(x::Base.TwicePrecision, y::Quantity) = (x * ustrip(y)) * unit(y)
 function colon(start::T, step::T, stop::T) where (T<:Quantity{S}
     where S<:Union{Float16,Float32,Float64})
     # This will always return a StepRangeLen

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -892,6 +892,10 @@ end
             @test @inferred((1:5)*mm) === 1mm:1mm:5mm
             @test @inferred((1:2:5)*mm) === 1mm:2mm:5mm
             @test @inferred((1.0:2.0:5.01)*mm) === 1.0mm:2.0mm:5.0mm
+            r = @inferred(range(0.1, 0.1, 3) * 1.0s)
+            if VERSION >= v"0.6.0-pre"
+                @test r[3] === 0.3s
+            end
         end
     end
     @testset "> Arrays" begin


### PR DESCRIPTION
Fixes #85. I decided that the [definition of this operation for other `Number` types](https://github.com/JuliaLang/julia/blob/bc606f6cc8bc6127979d90c6ccb239b2e2a14448/base/twiceprecision.jl#L486-L489) doesn't really make sense for Unitful, anyway.