### PR TITLE
Adds overloads for `rand` and `ones`

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -26,6 +26,7 @@ import Base: length, float, start, done, next, last, one, zero, colon#, range
 import Base: getindex, eltype, step, last, first, frexp
 import Base: Integer, Rational, typemin, typemax
 import Base: steprange_last, unsigned
+import Base: rand, ones
 
 import Base.LinAlg: istril, istriu
 
@@ -1108,6 +1109,13 @@ for (fun,pow) in ((:inv, -1//1), (:sqrt, 1//2), (:cbrt, 1//3))
         :($y)
     end
 end
+
+rand(Q::Type{<: Quantity}) = reinterpret(Q, rand(typeof(one(Q))))
+rand(Q::Type{<: Quantity}, dims::Tuple{Vararg{Int64}}) =
+    reinterpret(Q, rand(typeof(one(Q)), dims))
+ones(Q::Type{<: Quantity}, dims::Tuple{Vararg{Int}}) =
+    fill!(Array{Q}(dims), oneunit(Q))
+
 
 include("Display.jl")
 include("Promotion.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1048,6 +1048,13 @@ end
             @test istril([1 1; 0 1]u"m") == false
             @test istriu([1 1; 0 1]u"m") == true
         end
+
+        @testset ">> Array initialization" begin
+            Q = typeof(1u"m")
+            @test all(@inferred(zeros(Q, 2)) .== [0, 0]u"m")
+            @test all(@inferred(ones(Q, 2)) .== [1, 1]u"m")
+            @test eltype(@inferred(rand(Q, 2)))  == Q
+        end
     end
 end
 


### PR DESCRIPTION
Overload for `ones` might not be necessary if JuliaLang/julia#23544 is accepted.