### PR TITLE
don't warn for identical units when resolving symbols from u"..."

### DIFF
--- a/src/user.jl
+++ b/src/user.jl
@@ -360,22 +360,34 @@ dottify(s) = s
 dottify() = Main        # needed because fullname(Main) == (). TODO: How to test?
 
 function replace_value(sym::Symbol)
-    where = [isdefined(unitmodules[i], sym) for i in eachindex(unitmodules)]
-    count = reduce(+, 0, where)
-    if count == 0
+    # `modules` is a dictionary that maps the value of `module.sym` to the module it
+    # is defined in.  Because we are using a dictionary, identical units will be
+    # automatically combined into one entry.
+    modules = Dict(getfield(m, sym)=>m for m in unitmodules if isdefined(m, sym))
+    filter!((u, m)->ustrcheck_bool(u), modules) # make sure the symbol is a unit
+
+    # One drawback of this approach is that dictionaries are unordered, so if
+    # multiple units with the same name are defined, we can't guarantee which one is
+    # being selected by `first(...)`.
+    u = first(keys(modules))
+    m = modules[u] # the module the unit is defined in
+
+    if length(modules) == 0
         error("Symbol $sym could not be found in registered unit modules.")
+    elseif length(modules) > 1
+        warn("Symbol $sym was found in multiple registered unit modules. ",
+             "We will use the one from $m.")
     end
 
-    m = unitmodules[findlast(where)]
-    expr = Expr(:(.), dottify(fullname(m)...), QuoteNode(sym))
-    if count > 1
-        warn("Symbol $sym was found in multiple registered unit modules. ",
-        "We will use the one from $m.")
-    end
-    return :(Unitful.ustrcheck($expr))
+    return u
 end
 
 replace_value(literal::Number) = literal
+
+ustrcheck_bool(::Units) = true
+ustrcheck_bool(::Dimensions) = true
+ustrcheck_bool(::Quantity) = true
+ustrcheck_bool(::Any) = false
 
 ustrcheck(x::Union{Units,Dimensions}) = x
 ustrcheck(x::Quantity) = x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -286,16 +286,12 @@ end
 end
 
 @testset "Unit string macro" begin
-    @test macroexpand(:(u"m")) == :(Unitful.ustrcheck(Unitful.m))
-    @test macroexpand(:(u"m,s")) ==
-        :(Unitful.ustrcheck(Unitful.m), Unitful.ustrcheck(Unitful.s))
+    @test macroexpand(:(u"m")) == :(Unitful.m)
+    @test macroexpand(:(u"m,s")) == :(Unitful.m, Unitful.s)
     @test macroexpand(:(u"1.0")) == 1.0
-    @test macroexpand(:(u"m/s")) ==
-        :(Unitful.ustrcheck(Unitful.m) / Unitful.ustrcheck(Unitful.s))
-    @test macroexpand(:(u"1.0m/s")) ==
-        :((1.0 * Unitful.ustrcheck(Unitful.m)) / Unitful.ustrcheck(Unitful.s))
-    @test macroexpand(:(u"m^-1")) ==
-        :(Unitful.ustrcheck(Unitful.m) ^ -1)
+    @test macroexpand(:(u"m/s")) == :(Unitful.m / Unitful.s)
+    @test macroexpand(:(u"1.0m/s")) == :((1.0 * Unitful.m) / Unitful.s)
+    @test macroexpand(:(u"m^-1")) == :(Unitful.m ^ -1)
     @test isa(macroexpand(:(u"N m")).args[1], ParseError)
     @test isa(macroexpand(:(u"abs(2)")).args[1], ErrorException)
 
@@ -303,7 +299,7 @@ end
     @test u"h" == Unitful.h
 
     # test ustrcheck(x) fallback to catch non-units / quantities
-    @test_throws ErrorException u"ustrcheck"
+    @test_throws ErrorException @eval u"basefactor"
 end
 
 @testset "Unit and dimensional analysis" begin


### PR DESCRIPTION
This is just a quick patch I whipped up to try and address #94. Basically, if two units have the same hash, we will no longer warn about finding two copies of the same unit. We also check that these symbols are actually units before warning (I think just having a symbol named "s" was enough to get the warning).

Unfortunately there is a drawback to the approach I've used here. Because Dicts are unordered, I  think there's no longer any guarantee about which unit is selected in the event that there are in fact multiple units with the same name.

*Before:*
```
julia> using Unitful

julia> module UnitfulTest
           import Unitful
           using Unitful: @unit, s
           @unit twoseconds "twoseconds" TwoSeconds 2s false
           Unitful.register(UnitfulTest)
       end
UnitfulTest

julia> uconvert(u"s", 1*u"twoseconds")
WARNING: Symbol s was found in multiple registered unit modules. We will use the one from UnitfulTest.
2//1 s
```

*After:*
```
julia> using Unitful

julia> module UnitfulTest
           import Unitful
           using Unitful: @unit, s
           @unit twoseconds "twoseconds" TwoSeconds 2s false
           Unitful.register(UnitfulTest)
       end
UnitfulTest

julia> uconvert(u"s", 1*u"twoseconds")
2//1 s

julia> module UnitfulTest2
           import Unitful
           using Unitful: @unit
           @unit s "weird" Weird 1Unitful.m false
           Unitful.register(UnitfulTest2)
       end
UnitfulTest2

julia> uconvert(u"s", 1*u"twoseconds")
WARNING: Symbol s was found in multiple registered unit modules. We will use the one from UnitfulTest.
2//1 s
```