### PR TITLE
added convertion to julia's Dates.Time (function, doc string, docs, a…

### DIFF
--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -71,6 +71,18 @@ julia> uconvert(u"K", 21.0u"°C")
 294.15 K
 ```
 
+### Time conversion
+
+To convert from some time quantity to the time representation native to Julia,
+use `uconvert(Dates.CompoundPeriod, x)`. This allows for the conversion of 
+floats to the integer-based representation in Julia. Note that in some cases 
+accuracy will be lost (e.g. `uconvert(Dates.CompoundPeriod, 1.1u"ns") → 1 nanosecond`). 
+
+```jldoctest
+julia> uconvert(Dates.CompoundPeriod, π*u"s")
+3 seconds, 141 milliseconds, 592 microseconds, 653 nanoseconds
+```
+
 ## Basic promotion mechanisms
 
 We decide the result units for addition and subtraction operations based on looking at the

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -1119,6 +1119,7 @@ else
 end
 include("pkgdefaults.jl")
 include("temperature.jl")
+include("time.jl")
 
 function __init__()
     # @u_str should be aware of units defined in module Unitful

--- a/src/time.jl
+++ b/src/time.jl
@@ -1,0 +1,19 @@
+"""
+uconvert{T,D,U}(a::Units, x::Quantity{T,typeof(𝚯),<:Time})
+In this method, we are special-casing time conversion to Julia's native
+time units. The maximal time unit is days (and the smallest is nanoseconds).
+"""
+function uconvert(::Type{Dates.CompoundPeriod}, x::Unitful.Time)
+    _nanos = ustrip(uconvert(ns, x))
+    nanos = floor(Int64, _nanos)
+    micros, nanos = fldmod(nanos, 1000)
+    millis, micros = fldmod(micros, 1000)
+    secs, millis = fldmod(millis, 1000)
+    mins, secs = fldmod(secs, 60)
+    hrs, mins = fldmod(mins, 60)
+    dys, hrs = fldmod(hrs, 24)
+    result = Dates.Nanosecond(nanos) + Dates.Microsecond(micros) +
+    Dates.Millisecond(millis) + Dates.Second(secs) +
+    Dates.Minute(mins) + Dates.Hour(hrs) + Dates.Day(dys)
+    return result
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1111,4 +1111,13 @@ end
     @test isa(TUM.fu^2, TUM.FakeDim212345Units)
 end
 
+@testset "Conversion to Julia time" begin
+    d = 2
+    h = 3
+    s = 4
+
+    @test uconvert(Dates.CompoundPeriod, (4 + 3*60*60 + 2*24*60*60)*u"s") == Dates.Day(d) + Dates.Hour(h) + Dates.Second(s)
+    @test uconvert(Dates.CompoundPeriod, π*u"s") == Dates.Second(3) + Dates.Millisecond(141) + Dates.Microsecond(592) + Dates.Nanosecond(653)
+end
+
 end


### PR DESCRIPTION
…nd tests)

This came about because of [this discussion](https://discourse.julialang.org/t/why-do-time-quantities-have-to-be-integers/5864?u=yakir12) on Discourse.