### PR TITLE
Change printing of default units to match their symbols

### DIFF
--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -78,7 +78,7 @@ end
 Unitful.offsettemp(::Unitful.Unit{:Celsius}) = 27315//100
 
 # Common units of time
-@unit minute "min"      Minute      60s                     false
+@unit minute "minute"   Minute      60s                     false
 @unit hr     "hr"       Hour        3600s                   false
 @unit d      "dy"       Day         86400s                  false
 @unit wk     "wk"       Week        604800s                 false

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -102,7 +102,7 @@ const q = 1.6021766208e-19*C        # CODATA 2014; `e` means 2.718...
 @unit eV     "eV"       eV          q*V                     true
 
 # For convenience
-@unit Hz2π   "Hz*2π"    AngHertz    2π/s                    true
+@unit Hz2π   "Hz2π"     AngHertz    2π/s                    true
 @unit bar    "bar"      Bar         100000Pa                true
 @unit atm    "atm"      Atmosphere  101325Pa                false
 @unit Torr   "Torr"     Torr        101325Pa//760           true
@@ -139,7 +139,7 @@ const σ  = π^2*k^4/(60*ħ^3*c^2)     # Stefan-Boltzmann constant
 
 # Length
 #key: Symbol    Display    Name         Equivalent to           10^n prefixes?
-@unit inch      "in"       Inch         (254//10000)*m          false
+@unit inch      "inch"     Inch         (254//10000)*m          false
 @unit ft        "ft"       Foot         12inch                  false
 @unit yd        "yd"       Yard         3ft                     false
 @unit mi        "mi"       Mile         1760yd                  false


### PR DESCRIPTION
Fixes #104 

This changes three units in `pkgdefaults.jl` so that for any unit X `u"X"` prints as `X`. This should make it a bit easier to remember whether the correct symbol for minutes is `u"minute"` and not `u"min"`, and likewise for inches and angular frequency. 