### PR TITLE
WIP: Nightly fixes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+Compat 0.33.0

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -1,5 +1,6 @@
 __precompile__(true)
 module Unitful
+using Compat
 
 import Base: ==, <, <=, +, -, *, /, //, ^
 import Base: show, convert

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -1,5 +1,8 @@
 """
-    *(a0::Dimensions, a::Dimensions...)
+```
+*(a0::Dimensions, a::Dimensions...)
+```
+
 Given however many dimensions, multiply them together.
 
 Collect [`Unitful.Dimension`](@ref) objects from the type parameter of the

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -1,5 +1,5 @@
 """
-    \*(a0::Dimensions, a::Dimensions...)
+    *(a0::Dimensions, a::Dimensions...)
 Given however many dimensions, multiply them together.
 
 Collect [`Unitful.Dimension`](@ref) objects from the type parameter of the
@@ -54,7 +54,7 @@ true
         end
     end
 
-    d = (c...)
+    d = (c...,)
     :(Dimensions{$d}())
 end
 

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -72,9 +72,17 @@ end
 # Exponentiation is not type-stable for `Dimensions` objects in many cases
 ^(x::Dimensions{T}, y::Integer) where {T} = *(Dimensions{map(a->a^y, T)}())
 ^(x::Dimensions{T}, y::Number) where {T} = *(Dimensions{map(a->a^y, T)}())
-@generated function Base.literal_pow(::typeof(^), x::Dimensions{T}, ::Type{Val{p}}) where {T,p}
-    z = *(Dimensions{map(a->a^p, T)}())
-    :($z)
+
+@static if VERSION < v"0.7.0-DEV.843"
+    @generated function Base.literal_pow(::typeof(^), x::Dimensions{T}, ::Type{Val{p}}) where {T,p}
+        z = *(Dimensions{map(a->a^p, T)}())
+        :($z)
+    end
+else
+    @generated function Base.literal_pow(::typeof(^), x::Dimensions{T}, ::Val{p}) where {T,p}
+        z = *(Dimensions{map(a->a^p, T)}())
+        :($z)
+    end
 end
 
 # Since exponentiation is not type stable, we define a special `inv` method to enable fast

--- a/src/display.jl
+++ b/src/display.jl
@@ -59,18 +59,6 @@ function show(io::IO, x::Quantity)
 end
 
 """
-    show{T,D,U}(io::IO, ::Type{Quantity{T,D,U}})
-Show the type of a unitful quantity in a succinct way. Otherwise,
-array summaries are nearly unreadable.
-"""
-function show(io::IO, ::Type{Quantity{T,D,U}}) where {T,D,U}
-    print(io, "Quantity{", string(T),
-            ", Dimensions:{", string(D()),
-            "}, Units:{", string(U()), "}}")
-    nothing
-end
-
-"""
     show(io::IO, x::Unitlike)
 Call [`Unitful.showrep`](@ref) on each object in the tuple that is the type
 variable of a [`Unitful.Units`](@ref) or [`Unitful.Dimensions`](@ref) object.

--- a/src/fastmath.jl
+++ b/src/fastmath.jl
@@ -1,6 +1,6 @@
 import Base.FastMath
 import Core.Intrinsics:
-    sqrt_llvm_fast,
+    sqrt_llvm,
     neg_float_fast,
     add_float_fast,
     sub_float_fast,
@@ -161,7 +161,7 @@ pow_fast(x::Quantity, y::Integer) = x^y
 pow_fast(x::Quantity, y::Rational) = x^y
 
 sqrt_fast(x::Quantity{T}) where {T <: FloatTypes} =
-    Quantity(sqrt_llvm_fast(x.val), sqrt(unit(x)))
+    Quantity(sqrt_llvm(x.val), sqrt(unit(x)))
 
 for f in (:cos, :sin, :tan)
     f_fast = fast_op[f]

--- a/src/logarithm.jl
+++ b/src/logarithm.jl
@@ -348,7 +348,7 @@ Neper-based yield `ln`, and so on. Returns `x->log(base, x)` as a fallback.
 function logfn end
 logfn(x::LogInfo{N,10}) where {N} = log10
 logfn(x::LogInfo{N,2})  where {N} = log2
-logfn(x::LogInfo{N,e})  where {N} = log
+logfn(x::LogInfo{N,ℯ})  where {N} = log
 logfn(x::LogInfo{N,B})  where {N,B} = x->log(B,x)
 
 """
@@ -360,7 +360,7 @@ Neper-based yield `exp`, and so on. Returns `x->(base)^x` as a fallback.
 function expfn end
 expfn(x::LogInfo{N,10}) where {N} = exp10
 expfn(x::LogInfo{N,2})  where {N} = exp2
-expfn(x::LogInfo{N,e})  where {N} = exp
+expfn(x::LogInfo{N,ℯ})  where {N} = exp
 expfn(x::LogInfo{N,B})  where {N,B} = x->B^x
 
 Base.rtoldefault(::Type{Level{L,S,T}}) where {L,S,T} =

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -168,8 +168,8 @@ Unitful.offsettemp(::Unitful.Unit{:Fahrenheit}) = 45967//100
 
 @logscale dB    "dB"       Decibel      10      10      false
 @logscale B     "B"        Bel          10      1       false
-@logscale Np    "Np"       Neper        e       1//2    true
-@logscale cNp   "cNp"      Centineper   e       50      true
+@logscale Np    "Np"       Neper        ℯ       1//2    true
+@logscale cNp   "cNp"      Centineper   ℯ       50      true
 
 @logunit  dBm   "dBm"      Decibel      1mW
 @logunit  dBV   "dBV"      Decibel      1V
@@ -254,17 +254,31 @@ consider invoking this function in your `.juliarc.jl` file which is loaded when
 you open Julia. This function is not exported.
 """
 function promote_to_derived()
-    Unitful.promote_unit(::S, ::T) where {S<:EnergyFreeUnits, T<:EnergyFreeUnits} = Unitful.J
-    Unitful.promote_unit(::S, ::T) where {S<:ForceFreeUnits, T<:ForceFreeUnits} = Unitful.N
-    Unitful.promote_unit(::S, ::T) where {S<:PowerFreeUnits, T<:PowerFreeUnits} = Unitful.W
-    Unitful.promote_unit(::S, ::T) where {S<:PressureFreeUnits, T<:PressureFreeUnits} = Unitful.Pa
-    Unitful.promote_unit(::S, ::T) where {S<:ChargeFreeUnits, T<:ChargeFreeUnits} = Unitful.C
-    Unitful.promote_unit(::S, ::T) where {S<:VoltageFreeUnits, T<:VoltageFreeUnits} = Unitful.V
-    Unitful.promote_unit(::S, ::T) where {S<:ResistanceFreeUnits, T<:ResistanceFreeUnits} = Unitful.Ω
-    Unitful.promote_unit(::S, ::T) where {S<:CapacitanceFreeUnits, T<:CapacitanceFreeUnits} = Unitful.F
-    Unitful.promote_unit(::S, ::T) where {S<:InductanceFreeUnits, T<:InductanceFreeUnits} = Unitful.H
-    Unitful.promote_unit(::S, ::T) where {S<:MagneticFluxFreeUnits, T<:MagneticFluxFreeUnits} = Unitful.Wb
-    Unitful.promote_unit(::S, ::T) where {S<:BFieldFreeUnits, T<:BFieldFreeUnits} = Unitful.T
-    Unitful.promote_unit(::S, ::T) where {S<:ActionFreeUnits, T<:ActionFreeUnits} = Unitful.J * Unitful.s
+    eval(quote
+         Unitful.promote_unit(::S, ::T) where
+         {S<:EnergyFreeUnits, T<:EnergyFreeUnits} = Unitful.J
+         Unitful.promote_unit(::S, ::T) where
+         {S<:ForceFreeUnits, T<:ForceFreeUnits} = Unitful.N
+         Unitful.promote_unit(::S, ::T) where
+         {S<:PowerFreeUnits, T<:PowerFreeUnits} = Unitful.W
+         Unitful.promote_unit(::S, ::T) where
+         {S<:PressureFreeUnits, T<:PressureFreeUnits} = Unitful.Pa
+         Unitful.promote_unit(::S, ::T) where
+         {S<:ChargeFreeUnits, T<:ChargeFreeUnits} = Unitful.C
+         Unitful.promote_unit(::S, ::T) where
+         {S<:VoltageFreeUnits, T<:VoltageFreeUnits} = Unitful.V
+         Unitful.promote_unit(::S, ::T) where
+         {S<:ResistanceFreeUnits, T<:ResistanceFreeUnits} = Unitful.Ω
+         Unitful.promote_unit(::S, ::T) where
+         {S<:CapacitanceFreeUnits, T<:CapacitanceFreeUnits} = Unitful.F
+         Unitful.promote_unit(::S, ::T) where
+         {S<:InductanceFreeUnits, T<:InductanceFreeUnits} = Unitful.H
+         Unitful.promote_unit(::S, ::T) where
+         {S<:MagneticFluxFreeUnits, T<:MagneticFluxFreeUnits} = Unitful.Wb
+         Unitful.promote_unit(::S, ::T) where
+         {S<:BFieldFreeUnits, T<:BFieldFreeUnits} = Unitful.T
+         Unitful.promote_unit(::S, ::T) where
+         {S<:ActionFreeUnits, T<:ActionFreeUnits} = Unitful.J * Unitful.s
+        end)
     nothing
 end

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -203,14 +203,13 @@ isless(x::Quantity, y::Quantity) = _isless(promote(x,y)...)
 isless(x::Quantity, y::Number) = _isless(promote(x,y)...)
 isless(x::Number, y::Quantity) = _isless(promote(x,y)...)
 
-@inline <(x::Quantity{T,D,U}, y::Quantity{T,D,U}) where {T,D,U} = _lt(x,y)
+<(x::Quantity, y::Quantity) = _lt(x,y)
 @inline _lt(x::Quantity{T,D,U}, y::Quantity{T,D,U}) where {T,D,U} = <(x.val,y.val)
+@inline _lt(x::Quantity{T,D,U1}, y::Quantity{T,D,U2}) where {T,D,U1,U2} = <(promote(x,y)...)
 @inline _lt(x::Quantity{T,D1,U1}, y::Quantity{T,D2,U2}) where {T,D1,D2,U1,U2} = throw(DimensionError(x,y))
-@inline _lt(x,y) = <(x,y)
 
-<(x::Quantity, y::Quantity) = _lt(promote(x,y)...)
-<(x::Quantity, y::Number) = _lt(promote(x,y)...)
-<(x::Number, y::Quantity) = _lt(promote(x,y)...)
+<(x::Quantity, y::Number) = <(promote(x,y)...)
+<(x::Number, y::Quantity) = <(promote(x,y)...)
 
 Base.rtoldefault(::Type{Quantity{T,D,U}}) where {T,D,U} = Base.rtoldefault(T)
 isapprox(x::Quantity{T,D,U}, y::Quantity{T,D,U}; atol=zero(Quantity{real(T),D,U}), kwargs...) where {T,D,U} =

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -359,6 +359,15 @@ end
 ^(x::Quantity, y::Rational) = Quantity((x.val)^y, unit(x)^y)
 ^(x::Quantity, y::Real) = Quantity((x.val)^y, unit(x)^y)
 
-Base.rand(r::AbstractRNG, ::Type{Quantity{T,D,U}}) where {T,D,U} = rand(r,T)*U()
-Base.ones(Q::Type{<:Quantity}, dims::Tuple) = fill!(Array{Q}(dims), oneunit(Q))
+@static if VERSION >= v"0.7.0-DEV.2708" #julia PR 23964
+    Base.rand(r::AbstractRNG, ::Base.Random.SamplerType{Quantity{T,D,U}}) where {T,D,U} =
+        rand(r, T) * U()
+else
+    Base.rand(r::AbstractRNG, ::Type{Quantity{T,D,U}}) where {T,D,U} = rand(r,T) * U()
+end
+@static if VERSION >= v"0.7.0-DEV.2581" #julia PR 24652
+    Base.ones(Q::Type{<:Quantity}, dims::Tuple) = fill!(Array{Q}(uninitialized, dims), oneunit(Q))
+else
+    Base.ones(Q::Type{<:Quantity}, dims::Tuple) = fill!(Array{Q}(dims), oneunit(Q))
+end
 Base.ones(a::AbstractArray, Q::Type{<:Quantity}) = fill!(similar(a,Q), oneunit(Q))

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -222,7 +222,7 @@ isapprox(x::Quantity, y::Number; kwargs...) = isapprox(promote(x,y)...; kwargs..
 isapprox(x::Number, y::Quantity; kwargs...) = isapprox(y, x; kwargs...)
 
 function isapprox(x::AbstractArray{Quantity{T1,D,U1}},
-        y::AbstractArray{Quantity{T2,D,U2}}; rtol::Real=Base.rtoldefault(T1,T2),
+        y::AbstractArray{Quantity{T2,D,U2}}; rtol::Real=Base.rtoldefault(T1,T2,0),
         atol=zero(Quantity{T1,D,U1}), norm::Function=vecnorm) where {T1,D,U1,T2,U2}
 
     d = norm(x - y)

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -344,9 +344,15 @@ typemin(x::Quantity{T}) where {T} = typemin(T)*unit(x)
 typemax(::Type{Quantity{T,D,U}}) where {T,D,U} = typemax(T)*U()
 typemax(x::Quantity{T}) where {T} = typemax(T)*unit(x)
 
-Base.literal_pow(::typeof(^), x::Quantity, ::Type{Val{v}}) where {v} =
-    Quantity(Base.literal_pow(^, x.val, Val{v}),
-             Base.literal_pow(^, unit(x), Val{v}))
+@static if VERSION < v"0.7.0-DEV.843"
+    Base.literal_pow(::typeof(^), x::Quantity, ::Type{Val{v}}) where {v} =
+        Quantity(Base.literal_pow(^, x.val, Val{v}),
+                 Base.literal_pow(^, unit(x), Val{v}))
+else
+    Base.literal_pow(::typeof(^), x::Quantity, ::Val{v}) where {v} =
+        Quantity(Base.literal_pow(^, x.val, Val(v)),
+                 Base.literal_pow(^, unit(x), Val(v)))
+end
 
 # All of these are needed for ambiguity resolution
 ^(x::Quantity, y::Integer) = Quantity((x.val)^y, unit(x)^y)

--- a/src/range.jl
+++ b/src/range.jl
@@ -81,11 +81,10 @@ range(a::Quantity{<:Real}, st::Quantity{<:AbstractFloat}, len::Integer) =
     range(float(a), st, len)
 range(a::Quantity{<:AbstractFloat}, st::Quantity{<:Real}, len::Integer) =
     range(a, float(st), len)
-range(a::Quantity{<:AbstractFloat}, st::Quantity{<:AbstractFloat}, len::Integer) =
-    _range(promote(a, st)..., len)
-_range(a::T, st::T, len) where {T<:Quantity} = range(a, st, len)
-_range(a, st, len) = throw(DimensionError(a, st))
-
+function range(a::Quantity{<:AbstractFloat}, st::Quantity{<:AbstractFloat}, len::Integer)
+    dimension(a) != dimension(st) && throw(DimensionError(a, st))
+    range(promote(a, st)..., len)
+end
 range(a::Quantity, st::Real, len::Integer) = range(promote(a, st)..., len)
 range(a::Real, st::Quantity, len::Integer) = range(promote(a, st)..., len)
 

--- a/src/range.jl
+++ b/src/range.jl
@@ -1,6 +1,8 @@
-*(y::Units, r::Range) = *(r,y)
-*(r::Range, y::Units) = range(first(r)*y, step(r)*y, length(r))
-*(r::Range, y::Units, z::Units...) = *(x, *(y,z...))
+using Compat: AbstractRange
+
+*(y::Units, r::AbstractRange) = *(r,y)
+*(r::AbstractRange, y::Units) = range(first(r)*y, step(r)*y, length(r))
+*(r::AbstractRange, y::Units, z::Units...) = *(x, *(y,z...))
 
 Base.linspace(start::Quantity{<:Real}, stop, len::Integer) =
     _linspace(promote(start, stop)..., len)

--- a/src/units.jl
+++ b/src/units.jl
@@ -107,17 +107,32 @@ true
 ^(x::FixedUnits{N}, y::Integer) where {N} = *(FixedUnits{map(a->a^y, N), ()}())
 ^(x::FixedUnits{N}, y::Number) where {N} = *(FixedUnits{map(a->a^y, N), ()}())
 
-@generated function Base.literal_pow(::typeof(^), x::FreeUnits{N}, ::Type{Val{p}}) where {N,p}
-    y = *(FreeUnits{map(a->a^p, N), ()}())
-    :($y)
-end
-@generated function Base.literal_pow(::typeof(^), x::ContextUnits{N,D,P}, ::Type{Val{p}}) where {N,D,P,p}
-    y = *(ContextUnits{map(a->a^p, N), (), typeof(P()^p)}())
-    :($y)
-end
-@generated function Base.literal_pow(::typeof(^), x::FixedUnits{N}, ::Type{Val{p}}) where {N,p}
-    y = *(FixedUnits{map(a->a^p, N), ()}())
-    :($y)
+@static if VERSION < v"0.7.0-DEV.843"
+    @generated function Base.literal_pow(::typeof(^), x::FreeUnits{N}, ::Type{Val{p}}) where {N,p}
+        y = *(FreeUnits{map(a->a^p, N), ()}())
+        :($y)
+    end
+    @generated function Base.literal_pow(::typeof(^), x::ContextUnits{N,D,P}, ::Type{Val{p}}) where {N,D,P,p}
+        y = *(ContextUnits{map(a->a^p, N), (), typeof(P()^p)}())
+        :($y)
+    end
+    @generated function Base.literal_pow(::typeof(^), x::FixedUnits{N}, ::Type{Val{p}}) where {N,p}
+        y = *(FixedUnits{map(a->a^p, N), ()}())
+        :($y)
+    end
+else
+    @generated function Base.literal_pow(::typeof(^), x::FreeUnits{N}, ::Val{p}) where {N,p}
+        y = *(FreeUnits{map(a->a^p, N), ()}())
+        :($y)
+    end
+    @generated function Base.literal_pow(::typeof(^), x::ContextUnits{N,D,P}, ::Val{p}) where {N,D,P,p}
+        y = *(ContextUnits{map(a->a^p, N), (), typeof(P()^p)}())
+        :($y)
+    end
+    @generated function Base.literal_pow(::typeof(^), x::FixedUnits{N}, ::Val{p}) where {N,p}
+        y = *(FixedUnits{map(a->a^p, N), ()}())
+        :($y)
+    end
 end
 
 # Since exponentiation is not type stable, we define a special `inv` method to enable fast

--- a/src/units.jl
+++ b/src/units.jl
@@ -44,7 +44,7 @@
     # results in:
     # [nm,cm^6,m^6,µs^3,s]
 
-    d = (c...)
+    d = (c...,)
     f = typeof(mapreduce(dimension, *, NoDims, d))
     :(FreeUnits{$d,$f}())
 end

--- a/src/user.jl
+++ b/src/user.jl
@@ -266,7 +266,7 @@ factory defaults, this function will return a product of powers of base SI units
 (as [`Unitful.FreeUnits`](@ref)).
 """
 @generated function upreferred(x::Dimensions{D}) where {D}
-    u = *(FreeUnits{((Unitful.promotion[name(z)]^z.power for z in D)...),()}())
+    u = *(FreeUnits{((Unitful.promotion[name(z)]^z.power for z in D)...,),()}())
     :($u)
 end
 
@@ -438,7 +438,7 @@ julia> u"ħ"
 ```
 """
 macro u_str(unit)
-    ex = parse(unit)
+    ex = Meta.parse(unit)
     esc(replace_value(ex))
 end
 
@@ -453,7 +453,7 @@ function replace_value(ex::Expr)
                 ex.args[i]=replace_value(ex.args[i])
             end
         end
-        return eval(current_module(), ex)
+        return eval(@__MODULE__, ex)
     elseif ex.head == :tuple
         for i=1:length(ex.args)
             if typeof(ex.args[i])==Symbol

--- a/src/user.jl
+++ b/src/user.jl
@@ -54,12 +54,12 @@ macro dimension(symb, abbr, name)
     funame = Symbol(name,"FreeUnits")
     esc(quote
         Unitful.abbr(::Unitful.Dimension{$x}) = $abbr
-        const $s = Unitful.Dimensions{(Unitful.Dimension{$x}(1),)}()
-        const ($name){T,U} = Union{
+        const global $s = Unitful.Dimensions{(Unitful.Dimension{$x}(1),)}()
+        const global ($name){T,U} = Union{
             Unitful.Quantity{T,typeof($s),U},
             Unitful.Level{L,S,Unitful.Quantity{T,typeof($s),U}} where {L,S}}
-        const ($uname){U} = Unitful.Units{U,typeof($s)}
-        const ($funame){U} = Unitful.FreeUnits{U,typeof($s)}
+        const global ($uname){U} = Unitful.Units{U,typeof($s)}
+        const global ($funame){U} = Unitful.FreeUnits{U,typeof($s)}
         $s
     end)
 end
@@ -83,11 +83,11 @@ macro derived_dimension(name, dims)
     uname = Symbol(name,"Units")
     funame = Symbol(name,"FreeUnits")
     esc(quote
-        const ($name){T,U} = Union{
+        const global ($name){T,U} = Union{
             Unitful.Quantity{T,typeof($dims),U},
             Unitful.Level{L,S,Unitful.Quantity{T,typeof($dims),U}} where {L,S}}
-        const ($uname){U} = Unitful.Units{U,typeof($dims)}
-        const ($funame){U} = Unitful.FreeUnits{U,typeof($dims)}
+        const global ($uname){U} = Unitful.Units{U,typeof($dims)}
+        const global ($funame){U} = Unitful.FreeUnits{U,typeof($dims)}
         nothing
     end)
 end
@@ -206,7 +206,7 @@ macro prefixed_unit_symbols(symb,name,dimension,basefactor)
         u = :(Unitful.Unit{$n, typeof($dimension)}($k,1//1))
         ea = quote
             Unitful.basefactors[$n] = $basefactor
-            const $s = Unitful.FreeUnits{($u,),typeof(Unitful.dimension($u))}()
+            const global $s = Unitful.FreeUnits{($u,),typeof(Unitful.dimension($u))}()
         end
         push!(expr.args, ea)
     end
@@ -216,7 +216,7 @@ macro prefixed_unit_symbols(symb,name,dimension,basefactor)
     u = :(Unitful.Unit{$n, typeof($dimension)}(-6,1//1))
     push!(expr.args, quote
         Unitful.basefactors[$n] = $basefactor
-        const $s = Unitful.FreeUnits{($u,),typeof(Unitful.dimension($u))}()
+        const global $s = Unitful.FreeUnits{($u,),typeof(Unitful.dimension($u))}()
     end)
 
     esc(expr)
@@ -235,7 +235,7 @@ macro unit_symbols(symb,name,dimension,basefactor)
     u = :(Unitful.Unit{$n,typeof($dimension)}(0,1//1))
     esc(quote
         Unitful.basefactors[$n] = $basefactor
-        const $s = Unitful.FreeUnits{($u,),typeof(Unitful.dimension($u))}()
+        const global $s = Unitful.FreeUnits{($u,),typeof(Unitful.dimension($u))}()
     end)
 end
 
@@ -359,10 +359,10 @@ macro logscale(symb,abbr,name,base,prefactor,irp)
     quote
         Unitful.abbr(::Unitful.LogInfo{$(QuoteNode(name))}) = $abbr
 
-        const $(esc(name)) = Unitful.LogInfo{$(QuoteNode(name)), $base, $prefactor}
+        const global $(esc(name)) = Unitful.LogInfo{$(QuoteNode(name)), $base, $prefactor}
         Unitful.isrootpower(::Type{$(esc(name))}) = $irp
 
-        const $(esc(symb)) = Unitful.MixedUnits{Unitful.Gain{$(esc(name))}}()
+        const global $(esc(symb)) = Unitful.MixedUnits{Unitful.Gain{$(esc(name))}}()
 
         macro $(esc(symb))(::Union{Real,Symbol})
             throw(ArgumentError(join(["usage: `@", $(String(symb)), " (a)/(b)`"])))
@@ -421,7 +421,7 @@ Defines a logarithmic unit. For examples see `src/pkgdefaults.jl`.
 macro logunit(symb, abbr, logscale, reflevel)
     quote
         Unitful.abbr(::Unitful.Level{$(esc(logscale)), $(esc(reflevel))}) = $abbr
-        const $(esc(symb)) =
+        const global $(esc(symb)) =
             Unitful.MixedUnits{Unitful.Level{$(esc(logscale)), $(esc(reflevel))}}()
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -65,7 +65,11 @@ julia> a[1] = 3u"m"; b
 Strip units from various kinds of matrices by calling `ustrip` on the underlying vectors.
 """
 ustrip(A::Diagonal) = Diagonal(ustrip(A.diag))
-ustrip(A::Bidiagonal) = Bidiagonal(ustrip(A.dv), ustrip(A.ev), A.isupper)
+@static if VERSION >= v"0.7.0-DEV.884" # PR 22703
+    ustrip(A::Bidiagonal) = Bidiagonal(ustrip(A.dv), ustrip(A.ev), ifelse(istriu(A), :U, :L))
+else
+    ustrip(A::Bidiagonal) = Bidiagonal(ustrip(A.dv), ustrip(A.ev), istriu(A))
+end
 ustrip(A::Tridiagonal) = Tridiagonal(ustrip(A.dl), ustrip(A.d), ustrip(A.du))
 ustrip(A::SymTridiagonal) = SymTridiagonal(ustrip(A.dv), ustrip(A.ev))
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -176,16 +176,17 @@ Unitful.Dimensions{()}
 @deprecate(dimension(x::AbstractArray{T}) where {T<:Units}, dimension.(x))
 
 """
-    mutable struct DimensionError{T,S} <: Exception
-      x::T
-      y::S
+    struct DimensionError <: Exception
+      x
+      y
     end
 Thrown when dimensions don't match in an operation that demands they do.
 Display `x` and `y` in error message.
 """
-mutable struct DimensionError{T,S} <: Exception
-    x::T
-    y::S
+struct DimensionError <: Exception
+    x
+    y
 end
+
 Base.showerror(io::IO, e::DimensionError) =
     print(io, "DimensionError: $(e.x) and $(e.y) are not dimensionally compatible.");

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -603,9 +603,9 @@ end
         @test_throws DimensionError fma(2, 1m, 1V)
     end
     @testset "> @fastmath" begin
-        const one32 = one(Float32)*m
-        const eps32 = eps(Float32)*m
-        const eps32_2 = eps32/2
+        one32 = one(Float32)*m
+        eps32 = eps(Float32)*m
+        eps32_2 = eps32/2
 
         # Note: Cannot use local functions since these are not yet optimized
         fm_ieee_32(x) = x + eps32_2 + eps32_2
@@ -614,9 +614,9 @@ end
         @test (fm_fast_32(one32) == one32 ||
             fm_fast_32(one32) == one32 + eps32 > one32)
 
-        const one64 = one(Float64)*m
-        const eps64 = eps(Float64)*m
-        const eps64_2 = eps64/2
+        one64 = one(Float64)*m
+        eps64 = eps(Float64)*m
+        eps64_2 = eps64/2
 
         # Note: Cannot use local functions since these are not yet optimized
         fm_ieee_64(x) = x + eps64_2 + eps64_2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 module UnitfulTests
 
 using Unitful
-using Base.Test
+using Compat.Test
 
 import Unitful: DimensionError
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -821,8 +821,8 @@ end
     @test @inferred(conj((3+4im)V)) == (3-4im)V
     @test @inferred(typemin(1.0m)) == -Inf*m
     @test @inferred(typemax(typeof(1.0m))) == Inf*m
-    @test @inferred(typemin(0x01m)) == 0x00m
-    @test @inferred(typemax(typeof(0x01m))) == 0xffm
+    @test @inferred(typemin(0x01*m)) == 0x00*m
+    @test @inferred(typemax(typeof(0x01*m))) == 0xff*m
     @test @inferred(rand(typeof(1u"m"))) isa typeof(1u"m")
     @test @inferred(rand(MersenneTwister(0), typeof(1u"m"))) isa typeof(1u"m")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -956,20 +956,20 @@ end
             @test typeof([3m,4m] * [1 2])        == Array{typeof(1u"m"),2}
         end
         @testset ">> Element-wise multiplication" begin
-            @test @inferred([1m, 2m, 3m] * 5)          == [5m, 10m, 15m]
-            @test typeof([1m, 2m, 3m] * 5)             == Array{typeof(1u"m"),1}
-            @test @inferred([1m, 2m, 3m] .* 5m)        == [5m^2, 10m^2, 15m^2]
-            @test typeof([1m, 2m, 3m] * 5m)            == Array{typeof(1u"m^2"),1}
-            @test @inferred(5m .* [1m, 2m, 3m])        == [5m^2, 10m^2, 15m^2]
-            @test typeof(5m .* [1m, 2m, 3m])           == Array{typeof(1u"m^2"),1}
-            @test @inferred(eye(2)*V)                  == [1.0V 0.0V; 0.0V 1.0V]
-            @test @inferred(V*eye(2))                  == [1.0V 0.0V; 0.0V 1.0V]
-            @test @inferred(eye(2).*V)                 == [1.0V 0.0V; 0.0V 1.0V]
-            @test @inferred(V.*eye(2))                 == [1.0V 0.0V; 0.0V 1.0V]
-            @test @inferred([1V 2V; 0V 3V].*2)         == [2V 4V; 0V 6V]
-            @test @inferred([1V, 2V] .* [true, false]) == [1V, 0V]
-            @test @inferred([1.0m, 2.0m] ./ 3)         == [1m/3, 2m/3]
-            @test @inferred([1V, 2.0V] ./ [3m, 4m])    == [1V/(3m), 0.5V/m]
+            @test @inferred([1m, 2m, 3m] * 5)            == [5m, 10m, 15m]
+            @test typeof([1m, 2m, 3m] * 5)               == Array{typeof(1u"m"),1}
+            @test @inferred([1m, 2m, 3m] .* 5m)          == [5m^2, 10m^2, 15m^2]
+            @test typeof([1m, 2m, 3m] * 5m)              == Array{typeof(1u"m^2"),1}
+            @test @inferred(5m .* [1m, 2m, 3m])          == [5m^2, 10m^2, 15m^2]
+            @test typeof(5m .* [1m, 2m, 3m])             == Array{typeof(1u"m^2"),1}
+            @test @inferred(Matrix{Float64}(I, 2, 2)*V)  == [1.0V 0.0V; 0.0V 1.0V]
+            @test @inferred(V*Matrix{Float64}(I, 2, 2))  == [1.0V 0.0V; 0.0V 1.0V]
+            @test @inferred(Matrix{Float64}(I, 2, 2).*V) == [1.0V 0.0V; 0.0V 1.0V]
+            @test @inferred(V.*Matrix{Float64}(I, 2, 2)) == [1.0V 0.0V; 0.0V 1.0V]
+            @test @inferred([1V 2V; 0V 3V].*2)           == [2V 4V; 0V 6V]
+            @test @inferred([1V, 2V] .* [true, false])   == [1V, 0V]
+            @test @inferred([1.0m, 2.0m] ./ 3)           == [1m/3, 2m/3]
+            @test @inferred([1V, 2.0V] ./ [3m, 4m])      == [1V/(3m), 0.5V/m]
 
             @test @inferred([1, 2]kg)                  == [1, 2] * kg
             @test @inferred([1, 2]kg .* [2, 3]kg^-1)   == [2, 6]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ module UnitfulTests
 
 using Unitful
 using Compat.Test
-
 import Unitful: DimensionError
 
 import Unitful: LogScaled, LogInfo, Level, Gain, MixedUnits, Decibel
@@ -1268,7 +1267,7 @@ end
 # (and incidentally, for Compat macro hygiene in @dimension, @derived_dimension)
 module TUM
     using Unitful
-    using Base.Test
+    using Compat.Test
 
     @dimension f "f" FakeDim12345
     @derived_dimension FakeDim212345 f^2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -661,7 +661,7 @@ end
             end
         end
 
-        for T in (Complex64, Complex128, Complex{BigFloat})
+        for T in (Complex{Float32}, Complex{Float64}, Complex{BigFloat})
             _zero = convert(T, 0)*m
             _one = convert(T, 1)*m + im*eps(real(convert(T,1)))*m
             _two = convert(T, 2)*m + im*m//10
@@ -724,7 +724,7 @@ end
         end
 
         # complex arithmetic
-        for T in (Complex64, Complex128, Complex{BigFloat})
+        for T in (Complex{Float32}, Complex{Float64}, Complex{BigFloat})
             half = (1+1im)V/T(2)
             third = (1-1im)V/T(3)
 
@@ -1015,7 +1015,11 @@ end
             @test @inferred(ustrip([1u"m", 2u"m"])) == [1,2]
             @test_warn "deprecated" ustrip([1,2])
             @test ustrip.([1,2]) == [1,2]
-            # @test typeof(ustrip([1u"m", 2u"m"])) == Array{Int,1} # TODO
+            @static if VERSION >= v"0.7.0-DEV.2083" # PR 23750
+                @test typeof(ustrip([1u"m", 2u"m"])) <: Base.ReinterpretArray{Int,1}
+            else
+                @test typeof(ustrip([1u"m", 2u"m"])) <: Array{Int,1}
+            end
             @test typeof(ustrip(Diagonal([1,2]u"m"))) <: Diagonal{Int}
             @static if VERSION >= v"0.7.0-DEV.884" # PR 22703
                 @test typeof(ustrip(Bidiagonal([1,2,3]u"m", [1,2]u"m", :U))) <:


### PR DESCRIPTION
Will fix #101. I was having problems with one of my packages on nightly because `using Unitful` errors on nightly/0.7, so I've fixed the errors. In particular, minor issues (mostly warnings) were:

 - `Range` -> `AbstractRange`
 - `(a...)` -> `(a...,)`
 - escape * in strings
 - `e` -> `ℯ`
 - `parse` -> `Meta.parse`
 - `current_module()` -> `@__MODULE__`
 - `Base.Test` -> `Compat.Test` and require Compat v0.33.0 to allow this
 - `sqrt_llvm_fast` no longer exists - use `sqrt_llvm`
 
And then there were major fixes to several macros:
 - `@unit`
 - `@prefixed_unit_symbols`
 - `@unit_symbols`

Unfortunately 0.6 is broken now - contrary to what I thought when making this PR as I messed up my testing. I can't get consistent behaviour between 0.6 and nightly. When one generates the right symbols, the other always produces nonsense. It's very frustrating - suggestions are welcome!

There are also still some errors when doing `Pkg.test("Unitful")` on nightly, particularly when creating new units. This is the biggest change of behaviour I see (though there are others):
```julia
@unit altL "altL" altLiter 1000*cm^3 true
```
What gets created now is `Unitful.altL` not `altL`, so I've added `import Unitful.altL` to the macro.