### PR TITLE
Allow logarithmic display of any dimension

### DIFF
--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -192,6 +192,7 @@ isrootpower_dim(::typeof(dimension(W/m^2)))     = false     # intensity
 isrootpower_dim(::typeof(𝐋^3))                  = false     # reflectivity
 isrootpower_dim(::typeof(dimension(Ω)))         = true
 isrootpower_dim(::typeof(dimension(S)))         = true
+isrootpower_dim(::Dimensions)                   = false     # allow logarithmic display of any dimension
 
 #########
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1226,6 +1226,7 @@ end
     @testset "> Display" begin
         @test Unitful.abbr(3u"dBm") == "dBm"
         @test Unitful.abbr(@dB 3V/1.241V) == "dB (1.241 V)"
+        @test string(@dB 2m/1m) == "3.010299956639812 dB (1 m)"
     end
 
     @testset "> Thanks for signing up for Log Facts!" begin


### PR DESCRIPTION
Currently things like `@dB 1m/m` can be created, but cannot be displayed to to this missing method.