### PR TITLE
Add CGS units missed on first go-around

### DIFF
--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -140,7 +140,10 @@ const σ  = π^2*k^4/(60*ħ^3*c^2)     # Stefan-Boltzmann constant
 
 
 # CGS units
+@unit Gal    "Gal"      Gal         1cm/s^2                 true
 @unit dyn    "dyn"      Dyne        1g*cm/s^2               true
+@unit erg    "erg"      Erg         1g*cm^2/s^2             true
+@unit Ba     "Ba"       Barye       1g/cm/s^2               true
 @unit P      "P"        Poise       1g/cm/s                 true
 @unit St     "St"       Stokes      1cm^2/s                 true
 


### PR DESCRIPTION
Should be all of them[1]. I'm not touching the electromagnetism stuff[2], though.

[1] https://en.wikipedia.org/wiki/Centimetre%E2%80%93gram%E2%80%93second_system_of_units#Definitions_and_conversion_factors_of_CGS_units_in_mechanics
[2] https://en.wikipedia.org/wiki/Centimetre%E2%80%93gram%E2%80%93second_system_of_units#Electromagnetic_units_in_various_CGS_systems