### PR TITLE
Proposal of additional units used in electrical engineering

### DIFF
--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -60,9 +60,12 @@ end
 # SI and related units
 @unit Hz     "Hz"       Hertz       1/s                     true
 @unit N      "N"        Newton      1kg*m/s^2               true
+@unit Nm     "Nm"       NewtonMeter 1N*m                    true
 @unit Pa     "Pa"       Pascal      1N/m^2                  true
 @unit J      "J"        Joule       1N*m                    true
 @unit W      "W"        Watt        1J/s                    true
+@unit VA     "VA"       VoltAmpere  1J/s                    true
+# @unit var     "var"     VoltAmpereReactive  1J/s            true
 @unit C      "C"        Coulomb     1A*s                    true
 @unit V      "V"        Volt        1W/A                    true
 @unit Ω      "Ω"        Ohm         1V/A                    true
@@ -77,12 +80,16 @@ end
 @unit Gy     "Gy"       Gray        1J/kg                   true
 @unit Sv     "Sv"       Sievert     1J/kg                   true
 @unit kat    "kat"      Katal       1mol/s                  true
+@unit percent "%"       Percent     1//100                  false
+@unit permille "‰"      Percent     1//1000                 false
 
 # Temperature
 @unit °C     "°C"       Celsius     1K                      true
 Unitful.offsettemp(::Unitful.Unit{:Celsius}) = 27315//100
 
 # Common units of time
+@unit rpm    "rpm"      RevolutionsPerMinute 1*u"minute^-1" false
+@unit rps    "rps"      RevolutionsPerSecond 1/s            false
 @unit minute "minute"   Minute      60s                     false
 @unit hr     "hr"       Hour        3600s                   false
 @unit d      "dy"       Day         86400s                  false


### PR DESCRIPTION
First of all, thanks for providing the package Unitful. I use it a lot, even when teaching my classes. I am using Julia and Unitful for the programming and scripting of electrical engineering applications. So I am not a high level programmer of Julia. I yet hope my proposal is formally correct and it makes it to one of the next versions of Unitful.  

I would like to propose some more units. Most of them are frequently used in electrical engineering, particularly for electric drives. I even added two more units "percent" and "permille" which make sense to non engineers as well. 

Electrical engineers use three different power terms when it comes to AC systems. I think it is worth explaining these different terms:  

- Real power, unit "W", see IEC, http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-42
- Apparent power, unit "VA", see IEC, http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-41 
- Reactive power, unit "var", see IEC, http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-44

The problem with unit "var" is here, that the function ```var``` is in Julia already used to calculate the variance of a vector or array. So there is obviously a name conflict. Possible solutions are:
1. Use unit "VA" instead of "var" as suggested by IEC, see http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-44; this is the simplest solution and it is fully backwards compatible to any future implementation of "var", whenever it may come.  
2. Use the non-standard unit "VAR" instead of "var", knowing that this is not standard compliant; this is possibly no good idea, since this change were non-backwards compatible to a future implementation of the unit "var"
3. Propose to rename function ```var``` to a different name, e.g., ```variance```. This will possibly cause a lot of trouble for the developers of the function ```var``` since this were a non-backwards compatible change. 

I would conclude to go for option 1 and thus to not implement a separate unit of the reactive power. There should then be a note explaining why "VA" shall be used for the reactive power, not "var".