### PR TITLE
Fix step-range indexing for TwicePrecision ranges

### DIFF
--- a/src/units.jl
+++ b/src/units.jl
@@ -272,3 +272,6 @@ end
 @static if VERSION >= v"0.7.0-DEV.4659"
     Base.broadcastable(x::Units) = Ref(x)
 end
+
+Base.nbitslen(::Type{Q}, len, offset) where Q<:Quantity =
+    Base.nbitslen(numtype(Q), len, offset)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -957,6 +957,8 @@ end
                 @test_throws Unitful.DimensionError linspace(1m, 10, 5)
                 @test_throws Unitful.DimensionError linspace(1, 10m, 5)
             end
+            r = linspace(1m, 3m, 3)
+            @test r[1:2:end] == linspace(1m, 3m, 2)
         end
         @testset ">> Range → Array" begin
             @test isa(collect(1m:1m:5m), Array{typeof(1m),1})


### PR DESCRIPTION
Fixes the following error:
```julia
julia> using Unitful: m

julia> r = linspace(1m, 3m, 3)
1.0 m:1.0 m:3.0 m

julia> r[1:2:end]
ERROR: MethodError: no method matching nbitslen(::Type{Unitful.Quantity{Float64,Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)},Unitful.FreeUnits{(Unitful.Unit{:Meter,Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}}(0, 1//1),),Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}}}}, ::Int64, ::Int64)
Closest candidates are:
  nbitslen(::Type{Float64}, ::Any, ::Any) at twiceprecision.jl:58
  nbitslen(::Type{Float32}, ::Any, ::Any) at twiceprecision.jl:59
  nbitslen(::Type{Float16}, ::Any, ::Any) at twiceprecision.jl:60
  ...
Stacktrace:
 [1] getindex(::StepRangeLen{Unitful.Quantity{Float64,Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)},Unitful.FreeUnits{(Unitful.Unit{:Meter,Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}}(0, 1//1),),Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}}},Base.TwicePrecision{Unitful.Quantity{Float64,Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)},Unitful.FreeUnits{(Unitful.Unit{:Meter,Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}}(0, 1//1),),Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}}}},Base.TwicePrecision{Unitful.Quantity{Float64,Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)},Unitful.FreeUnits{(Unitful.Unit{:Meter,Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}}(0, 1//1),),Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}}}}}, ::StepRange{Int64,Int64}) at ./twiceprecision.jl:217
```
