### PR TITLE
Fix AppVeyor build script for Julia ≥ 0.7

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
+  - C:\projects\julia\bin\julia -e "using InteractiveUtils; versioninfo();
       Pkg.clone(pwd(), \"Unitful\"); Pkg.build(\"Unitful\")"
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,4 +32,4 @@ build_script:
       Pkg.clone(pwd(), \"Unitful\"); Pkg.build(\"Unitful\")"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"Unitful\")"
+  - C:\projects\julia\bin\julia -e "using Pkg; Pkg.test(\"Unitful\")"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "using InteractiveUtils; versioninfo();
+  - C:\projects\julia\bin\julia -e "using InteractiveUtils, Pkg; versioninfo();
       Pkg.clone(pwd(), \"Unitful\"); Pkg.build(\"Unitful\")"
 
 test_script:


### PR DESCRIPTION
This fixes the AppVeyor build script which currently fails for Julia 1.0 since `versioninfo` has been moved to a stdlib package.