### PR TITLE
Try u_str without eval

### DIFF
--- a/src/user.jl
+++ b/src/user.jl
@@ -482,7 +482,7 @@ function replace_value(ex::Expr)
                 ex.args[i]=replace_value(ex.args[i])
             end
         end
-        return Core.eval(@__MODULE__, ex)
+        return ex 
     elseif ex.head == :tuple
         for i=1:length(ex.args)
             if typeof(ex.args[i])==Symbol
@@ -491,7 +491,7 @@ function replace_value(ex::Expr)
                 error("only use symbols inside the tuple.")
             end
         end
-        return Core.eval(@__MODULE__, ex)
+        return ex
     else
         error("Expr head $(ex.head) must equal :call or :tuple")
     end
@@ -505,7 +505,7 @@ function replace_value(sym::Symbol)
 
     m = unitmodules[inds[end]]
     u = getfield(m, sym)
-
+    
     any(u != u1 for u1 in getfield.(unitmodules[inds[1:(end-1)]], sym)) &&
         @warn(string("Symbol $sym was found in multiple registered unit modules. ",
          "We will use the one from $m."))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -292,14 +292,14 @@ end
 end
 
 @testset "Unit string macro" begin
-    @test macroexpand(@__MODULE__, :(u"m")) == m
-    @test macroexpand(@__MODULE__, :(u"m,s")) == (m,s)
-    @test macroexpand(@__MODULE__, :(u"1.0")) == 1.0
-    @test macroexpand(@__MODULE__, :(u"m/s")) == m/s
-    @test macroexpand(@__MODULE__, :(u"1.0m/s")) == 1.0m/s
-    @test macroexpand(@__MODULE__, :(u"m^-1")) == m^-1
-    @test macroexpand(@__MODULE__, :(u"dB/Hz")) == dB/Hz
-    @test macroexpand(@__MODULE__, :(u"3.0dB/Hz")) == 3.0dB/Hz
+    @test u"m" == m
+    @test u"m,s" == (m,s)
+    @test u"1.0" == 1.0
+    @test u"m/s" == m/s
+    @test u"1.0m/s" == 1.0m/s
+    @test u"m^-1" == m^-1
+    @test u"dB/Hz" == dB/Hz
+    @test u"3.0dB/Hz" == 3.0dB/Hz
     @test_throws LoadError macroexpand(@__MODULE__, :(u"N m"))
     @test_throws LoadError macroexpand(@__MODULE__, :(u"abs(2)"))
     @test_throws LoadError @eval u"basefactor"


### PR DESCRIPTION
This is to help with precompiling (#133). It's generally frowned upon to use `eval` in a macro. This is an attempt to return the expression rather than `eval`ing it. The main difference is that `u"N*m"` resolves to `Unitful.N * Unitful.m` whereas now, it resolves to the result of that multiplication.

Making `u_str` work with precompilation will make this macro useful in other packages (most other packages are going to want precompilation).

I tested this in a small package, and it does get rid of the `eval` warnings related to precompilation.
