### PR TITLE
Add link to UnitfulAtomic.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ mathematical operations and collections that are found in Julia base.
   package.
 - [UnitfulAstro.jl](https://github.com/mweastwood/UnitfulAstro.jl): Astronomical units.
 - [UnitfulAngles.jl](https://github.com/yakir12/UnitfulAngles.jl): More angular units, additional trigonometric functionalities, and clock-angle conversion.
+- [UnitfulAtomic.jl](https://github.com/sostock/UnitfulAtomic.jl): Easy conversion from and to atomic units.
 
 ### Feature additions
 


### PR DESCRIPTION
I have written a small supplemental package for dealing with atomic units:

https://github.com/sostock/UnitfulAtomic.jl

This PR adds a link to UnitfulAtomic.jl to the README.