### PR TITLE
fix one specialization

### DIFF
--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -254,7 +254,8 @@ zero(x::Quantity) = Quantity(zero(x.val), unit(x))
 zero(x::Type{Quantity{T,D,U}}) where {T,D,U} = zero(T)*U()
 
 one(x::Quantity) = one(x.val)
-one(x::Type{Quantity{T,D,U}}) where {T,D,U} = one(T)
+get_T(::Type{Quantity{T}}) where T = T
+one(x::Type{<:Quantity}) = one(get_T(x))
 
 isreal(x::Quantity) = isreal(x.val)
 isfinite(x::Quantity) = isfinite(x.val)


### PR DESCRIPTION
Either I'm not understanding something here or there's a bug. MWE:

```julia
using Unitful
a = [1.0u"s",1u"kg"]
eltype(a) <: Quantity{T,D,U} where {U,D,T} # True
(Quantity{T,D,U} where {T,D,U}) <: Number # True

Base.one(x::Type{Quantity{T,D,U}}) where {T,D,U} = one(T)
@which one(eltype(a)) # one(::Type{T}) where T<:Number in Base at number.jl:297
```

I don't understand how that could end up at the dispatch for Number since Quantity is a subtype

`eltype(a) # Quantity{Float64,D,U} where U where D`

`(Quantity{Float64,D,U} where U where D) <: Quantity{T,D,U} where {T,D,U} # true`

Anyways, this PR gives a workaround which makes sure that `one` is correctly specialized.