### PR TITLE
Separate absolute and relative temperature

### DIFF
--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -7,6 +7,7 @@
 @dimension 𝐓 "𝐓" Time
 @dimension 𝐈 "𝐈" Current
 @dimension 𝚯 "𝚯" Temperature    # This one is \mbfTheta
+@dimension abs𝚯 "abs𝚯" AbsTemperature
 @dimension 𝐉 "𝐉" Luminosity
 @dimension 𝐍 "𝐍" Amount
 
@@ -49,6 +50,7 @@ include("temperature.jl")
 @refunit  s       "s"      Second    𝐓           true
 @refunit  A       "A"      Ampere    𝐈            true
 @refunit  K       "K"      Kelvin    𝚯           true
+@refunit  absK    "absK"   AbsKelvin abs𝚯        true
 @refunit  cd      "cd"     Candela   𝐉            true
 @refunit  g       "g"      Gram      𝐌           true
 @refunit  mol     "mol"    Mole      𝐍           true
@@ -89,8 +91,9 @@ end
 @unit permille "‰"      Permille    1//1000                 false
 
 # Temperature
-@unit °C     "°C"       Celsius     1K                      true
-Unitful.offsettemp(::Unitful.Unit{:Celsius}) = 27315//100
+@unit °C     "°C"       Celsius             1K                      true
+@unit abs°C  "abs°C"    AbsCelsius          1absK                   true
+Unitful.offsettemp(::Unitful.Unit{:AbsCelsius}) = 27315//100
 
 # Common units of time
 @unit minute "minute"   Minute                60s           false
@@ -180,7 +183,8 @@ const R∞ = 10_973_731.568_508/m     # (65) Rydberg constant
 # Temperatures
 @unit °Ra       "°Ra"      Rankine              (5//9)*K                false
 @unit °F        "°F"       Fahrenheit           (5//9)*K                false
-Unitful.offsettemp(::Unitful.Unit{:Fahrenheit}) = 45967//100
+@unit abs°F     "abs°F"    AbsFahrenheit        (5//9)*absK             false
+Unitful.offsettemp(::Unitful.Unit{:AbsFahrenheit}) = 45967//100
 
 # Masses
 @unit lb        "lb"       Pound                0.45359237kg            false # is exact

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -11,8 +11,6 @@
 @dimension 𝐉 "𝐉" Luminosity
 @dimension 𝐍 "𝐍" Amount
 
-include("temperature.jl")
-
 # Define derived dimensions.
 @derived_dimension Area                     𝐋^2
 @derived_dimension Volume                   𝐋^3
@@ -93,7 +91,7 @@ end
 # Temperature
 @unit °C     "°C"       Celsius             1K                      true
 @unit abs°C  "abs°C"    AbsCelsius          1absK                   true
-Unitful.offsettemp(::Unitful.Unit{:AbsCelsius}) = 27315//100
+offsettemp(::Unitful.Unit{:AbsCelsius}) = 27315//100
 
 # Common units of time
 @unit minute "minute"   Minute                60s           false
@@ -184,7 +182,7 @@ const R∞ = 10_973_731.568_508/m     # (65) Rydberg constant
 @unit °Ra       "°Ra"      Rankine              (5//9)*K                false
 @unit °F        "°F"       Fahrenheit           (5//9)*K                false
 @unit abs°F     "abs°F"    AbsFahrenheit        (5//9)*absK             false
-Unitful.offsettemp(::Unitful.Unit{:AbsFahrenheit}) = 45967//100
+offsettemp(::Unitful.Unit{:AbsFahrenheit}) = 45967//100
 
 # Masses
 @unit lb        "lb"       Pound                0.45359237kg            false # is exact
@@ -325,3 +323,5 @@ function promote_to_derived()
         end)
     nothing
 end
+
+include("temperature.jl")

--- a/src/temperature.jl
+++ b/src/temperature.jl
@@ -30,3 +30,16 @@ offsets, if they do not appear in combination with other dimensions.
         end
     end
 end
+
+
+# Disallow binary arithmetic on absolute temperatures
+for op in [:+, :*, :/]
+    @eval ($op)(x::Quantity{S,typeof(abs𝚯),U1},
+        y::Quantity{T,typeof(abs𝚯),U2}) where {S,T,U1,U2} =
+        throw(DimensionError(x, y))   # TODO: custom error?
+end
+
+Base.promote_rule(::Type{Quantity{S1,typeof(abs𝚯),U1}},
+                  ::Type{Quantity{S2,typeof(abs𝚯),U2}}) where {S1,U1,S2,U2} =
+    # Not sure when this will be called, but it shouldn't be. 
+    throw(DimensionError(U1(), U2()))  

--- a/src/temperature.jl
+++ b/src/temperature.jl
@@ -55,8 +55,3 @@ end
     Quantity(ustrip(x) - ustrip(uconvert(unit(x), y)), relative_unit(unit(x)))
 
 
-Base.promote_rule(::Type{Quantity{S1,typeof(abs𝚯),U1}},
-                  ::Type{Quantity{S2,typeof(abs𝚯),U2}}) where {S1,U1,S2,U2} =
-    # Not sure when this will be called, but it's safer to disallow
-    # promotion between absolute temperatures.
-    throw(DimensionError(U1(), U2()))  

--- a/src/temperature.jl
+++ b/src/temperature.jl
@@ -10,7 +10,7 @@ In this method, we are special-casing temperature conversion to respect scale
 offsets, if they do not appear in combination with other dimensions.
 """
 @generated function uconvert(a::Units,
-        x::Quantity{T,typeof(𝚯),<:TemperatureUnits}) where {T}
+        x::Quantity{T,typeof(abs𝚯),<:AbsTemperatureUnits}) where {T}
     # TODO: test, may be able to get bad things to happen here when T<:LogScaled
     if a == typeof(unit(x))
         :(Quantity(x.val, a))

--- a/src/temperature.jl
+++ b/src/temperature.jl
@@ -50,6 +50,11 @@ for op in [:+, :-]
         Quantity($op(ustrip(x),ustrip(uconvert(relative_unit(unit(x)), y))), unit(x))
 end
 
+(-)(x::Quantity{S,typeof(abs𝚯),U1},
+    y::Quantity{T,typeof(abs𝚯),U2}) where {S,T,D,U1,U2} =
+    Quantity(ustrip(x) - ustrip(uconvert(unit(x), y)), relative_unit(unit(x)))
+
+
 Base.promote_rule(::Type{Quantity{S1,typeof(abs𝚯),U1}},
                   ::Type{Quantity{S2,typeof(abs𝚯),U2}}) where {S1,U1,S2,U2} =
     # Not sure when this will be called, but it's safer to disallow

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ import Unitful:
     nm, μm, mm, cm, m, km, inch, ft, mi,
     ac,
     mg, g, kg, A,
-    °Ra, °F, °C, K, abs°C, abs°F,
+    °Ra, °F, °C, K, abs°C, abs°F, absK,
     rad, °,
     ms, s, minute, hr,
     J, A, N, mol, cd, V,
@@ -29,6 +29,7 @@ import Unitful:
     Mass,
     Current,
     Temperature,
+    AbsTemperature,
     Action,
     Power
 
@@ -231,6 +232,11 @@ end
         @test Unitful.promote_unit(m,km,cm) === m
         @test Unitful.promote_unit(ContextUnits(m,mm), ContextUnits(km,cm)) ===
             FreeUnits(m)
+
+        # Absolute temperature special cases
+        @test_throws DimensionError 1abs°C + 1abs°C
+        @test_throws DimensionError 1abs°C + 1abs°F
+        @test_throws DimensionError 1abs°C * 1abs°F
     end
     @testset "> Simple promotion" begin
         # promotion should do nothing to units alone
@@ -358,6 +364,7 @@ end
     @test isa(1s, Time)
     @test isa(1A, Current)
     @test isa(1K, Temperature)
+    @test isa(1absK, AbsTemperature)
     @test isa(1cd, Luminosity)
     @test isa(2π*rad*1.0m, Length)
     @test isa(u"h", Action)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -185,6 +185,7 @@ end
             @test uconvert(°C, 45°F) == 25°C
             @test 1.0abs°C + 45°F == 26.0abs°C
             @test 1abs°C - 1K == 0abs°C
+            @test 40abs°C - 95abs°F == 5°C
 
             # When appearing w/ other units, we calculate
             # by converting between temperature intervals (no offsets).

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,6 +186,7 @@ end
             @test 1.0abs°C + 45°F == 26.0abs°C
             @test 1abs°C - 1K == 0abs°C
             @test 40abs°C - 95abs°F == 5°C
+            @test 35abs°C == 95abs°F
 
             # When appearing w/ other units, we calculate
             # by converting between temperature intervals (no offsets).

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ import Unitful:
     nm, μm, mm, cm, m, km, inch, ft, mi,
     ac,
     mg, g, kg, A,
-    °Ra, °F, °C, K,
+    °Ra, °F, °C, K, abs°C, abs°F,
     rad, °,
     ms, s, minute, hr,
     J, A, N, mol, cd, V,
@@ -178,8 +178,10 @@ end
             @test @inferred(unit(uconvert(ContextUnits(°Ra), 4.2K))) ===
                 ContextUnits(°Ra)
 
-            @test uconvert(°F, 0°C) == 32°F
-            @test uconvert(°C, 212°F) == 100°C
+            @test uconvert(abs°F, 0abs°C) == 32abs°F
+            @test uconvert(abs°C, 212abs°F) == 100abs°C
+            @test uconvert(°F, 0°C) == 0°F
+            @test uconvert(°C, 45°F) == 25°C
 
             # When appearing w/ other units, we calculate
             # by converting between temperature intervals (no offsets).

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -183,6 +183,8 @@ end
             @test uconvert(abs°C, 212abs°F) == 100abs°C
             @test uconvert(°F, 0°C) == 0°F
             @test uconvert(°C, 45°F) == 25°C
+            @test 1.0abs°C + 45°F == 26.0abs°C
+            @test 1abs°C - 1K == 0abs°C
 
             # When appearing w/ other units, we calculate
             # by converting between temperature intervals (no offsets).


### PR DESCRIPTION
Following the discussion in #137, I separated absolute and relative temperature units, similar to @burnpanck's suggestion. It works well so far. Notable new test cases:

```
            @test uconvert(abs°F, 0abs°C) == 32abs°F
            @test uconvert(°F, 0°C) == 0°F
            @test 1.0abs°C + 45°F == 26.0abs°C
            @test 1abs°C - 1K == 0abs°C
            @test 40abs°C - 95abs°F == 5°C
            @test_throws DimensionError 1abs°C + 1abs°F
```

This PR is a proposal for discussion. If the general approach is acceptable, then we might find a less ugly name than `35abs°C`. And of course: documentation.

Regarding binary arithmetic on absolute temperatures, we can either disallow promotion of two absolute temperatures in general, and explicitly allow some operations (`-, ==, ...?`) or allow all operations by default and disallow some (`+, *, /, ...?`) by throwing an exception. I did the latter in this PR, but I also tested the former and it works too.

Fix #137 and #72 