### PR TITLE
Support oneunit(°C)

### DIFF
--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -11,7 +11,7 @@ import Base: eps, mod, rem, div, fld, cld, trunc, round, sign, signbit
 import Base: isless, isapprox, isinteger, isreal, isinf, isfinite, isnan
 import Base: copysign, flipsign
 import Base: prevfloat, nextfloat, maxintfloat, rat, step
-import Base: length, float, last, one, zero, range
+import Base: length, float, last, one, oneunit, zero, range
 import Base: getindex, eltype, step, last, first, frexp
 import Base: Integer, Rational, typemin, typemax
 import Base: steprange_last, unsigned

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -293,6 +293,8 @@ zero(x::Type{Quantity{T,D,U}}) where {T,D,U<:AffineUnits} = zero(T)*absoluteunit
 one(x::Quantity) = one(x.val)
 one(x::AffineQuantity) =
     throw(AffineError("no multiplicative identity for affine quantity $x."))
+oneunit(x::AffineQuantity) = Quantity(one(x.val), absoluteunit(x))
+oneunit(x::Type{Quantity{T,D,U}}) where {T,D,U<:AffineUnits} = Quantity(one(T), absoluteunit(U()))
 get_T(::Type{Quantity{T}}) where T = T
 get_T(::Type{Quantity{T,D}}) where {T,D} = T
 get_T(::Type{Quantity{T,D,U}}) where {T,D,U} = T

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -197,6 +197,7 @@ end
         @test oneunit(typeof(100°C)) === 1K
         @test_throws AffineError one(100°C)
         @test_throws AffineError one(typeof(100°C))
+        
         @test 0°C isa AffineQuantity{T, typeof(𝚯)} where T    # is "relative temperature"
         @test 0°C isa Temperature                             # dimensional correctness
         @test °C isa AffineUnits{N, typeof(𝚯)} where N

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -193,11 +193,10 @@ end
 
         @test zero(100°C) === 0K
         @test zero(typeof(100°C)) === 0K
+        @test oneunit(100°C) === 1K
+        @test oneunit(typeof(100°C)) === 1K
         @test_throws AffineError one(100°C)
         @test_throws AffineError one(typeof(100°C))
-        @test_throws AffineError oneunit(100°C)
-        @test_throws AffineError oneunit(typeof(100°C))
-
         @test 0°C isa AffineQuantity{T, typeof(𝚯)} where T    # is "relative temperature"
         @test 0°C isa Temperature                             # dimensional correctness
         @test °C isa AffineUnits{N, typeof(𝚯)} where N


### PR DESCRIPTION
I don't have strong feelings about this one. As you said, the docstring is pretty clear, but, like `zero`, it's not respected in Base:

```julia
julia> typeof([1 2; 3 4]')
LinearAlgebra.Adjoint{Int64,Array{Int64,2}}

julia> typeof(oneunit([1 2; 3 4]'))
Array{Int64,2}
```

Fix #181 