### PR TITLE
Change type representations to shorten type signatures

### DIFF
--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -135,12 +135,12 @@ the following three cases:
 
 ```jldoctest
 julia> [1.0u"m", 2.0u"m"]
-2-element Array{Quantity{Float64, Dimensions:{𝐋}, Units:{m}},1}:
+2-element Array{Quantity{Float64,𝐋,Unitful.FreeUnits{(m,),𝐋,nothing}},1}:
  1.0 m
  2.0 m
 
 julia> [1.0u"m", 2.0u"cm"]
-2-element Array{Quantity{Float64, Dimensions:{𝐋}, Units:{m}},1}:
+2-element Array{Quantity{Float64,𝐋,Unitful.FreeUnits{(m,),𝐋,nothing}},1}:
   1.0 m
  0.02 m
 

--- a/docs/src/manipulations.md
+++ b/docs/src/manipulations.md
@@ -24,9 +24,9 @@ You can then query whether the units are `FreeUnits`, `FixedUnits`, etc.
 ```@docs
 Unitful.unit
 Unitful.dimension(::Number)
-Unitful.dimension{U,D}(::Unitful.Units{U,D})
-Unitful.dimension{T,D,U}(x::Quantity{T,D,U})
-Unitful.dimension{T<:Unitful.Units}(x::AbstractArray{T})
+Unitful.dimension(::Unitful.Units{U,D}) where {U,D}
+Unitful.dimension(x::Quantity{T,D,U}) where {T,D,U}
+Unitful.dimension(x::AbstractArray{T}) where {T<:Unitful.Units}
 ```
 
 ## Unit stripping

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -14,8 +14,8 @@ to avoid overflow issues and general ugliness.
 Usually, the user interacts only with `Units` objects, not `Unit` objects.
 This is because generically, more than one unit is needed to describe a quantity.
 An abstract type [`Unitful.Units{N,D}`](@ref) is defined, where `N` is always a tuple
-of `Unit` objects, and `D` is some type, like `typeof(Unitful.𝐋)`, where `𝐋` is the
-object representing the length dimension (see [`Unitful.Dimensions{N}`](@ref)).
+of `Unit` objects, and `D` is a [`Unitful.Dimensions{N}`](@ref) object such as `𝐋`, the
+object representing the length dimension.
 
 Subtypes of `Unitful.Units{N,D}` are used to implement different behaviors
 for how to promote dimensioned quantities. The concrete subtypes have no fields and
@@ -25,7 +25,7 @@ include [`Unitful.FreeUnits{N,D}`](@ref), [`Unitful.ContextUnits{N,D,P}`](@ref),
 `Unitful.FreeUnits{N,D}` objects.
 
 Finally, we define physical quantity types as [`Quantity{T<:Number, D, U}`](@ref), where
-`D <: Dimensions` and `U <: Units`. By putting units in the type signature of a
+`D :: Dimensions` and `U <: Units`. By putting units in the type signature of a
 quantity, staged functions can be used to offload as much of the unit
 computation to compile-time as is possible. By also having the dimensions
 explicitly in the type signature, dispatch can be done on dimensions:

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -100,7 +100,7 @@ Returns 1. (Avoids effort when unnecessary.)
 convfact(s::Units{S}, t::Units{S}) where {S} = 1
 
 function convert(::Type{Quantity{T,D,U}}, x::Number) where {T,D,U}
-    if dimension(x) == D()
+    if dimension(x) == D
         Quantity(T(uconvert(U(),x).val), U())
     else
         throw(DimensionError(U(),x))
@@ -111,18 +111,18 @@ end
 convert(::Type{Quantity{T,D,U}}, x::Quantity{T,D,U}) where {T,D,U} = x
 
 function convert(::Type{Quantity{T,D}}, x::Quantity) where {T,D}
-    (dimension(x) !== D()) && throw(DimensionError(D(), x))
+    (dimension(x) !== D) && throw(DimensionError(D, x))
     return Quantity{T,D,typeof(unit(x))}(convert(T, x.val))
 end
 function convert(::Type{Quantity{T,D}}, x::Number) where {T,D}
-    (D() !== NoDims) && throw(DimensionError(D(), NoDims))
-    Quantity{T,typeof(NoDims),typeof(NoUnits)}(x)
+    (D !== NoDims) && throw(DimensionError(D, NoDims))
+    Quantity{T,NoDims,typeof(NoUnits)}(x)
 end
 function convert(::Type{Quantity{T}}, x::Quantity) where {T}
-    Quantity{T,typeof(dimension(x)),typeof(unit(x))}(convert(T, x.val))
+    Quantity{T,dimension(x),typeof(unit(x))}(convert(T, x.val))
 end
 function convert(::Type{Quantity{T}}, x::Number) where {T}
-    Quantity{T,typeof(NoDims),typeof(NoUnits)}(x)
+    Quantity{T,NoDims,typeof(NoUnits)}(x)
 end
 
 convert(::Type{DimensionlessQuantity{T,U}}, x::Number) where {T,U} =

--- a/src/fastmath.jl
+++ b/src/fastmath.jl
@@ -47,12 +47,12 @@ sub_fast(x::Quantity{T,D,U}, y::Quantity{T,D,U}) where {T <: FloatTypes,D,U} =
     Quantity{T,D,U}(sub_float_fast(x.val, y.val))
 
 function mul_fast(x::Quantity{T}, y::Quantity{T}) where {T <: FloatTypes}
-    D = typeof(dimension(x) * dimension(y))
+    D = dimension(x) * dimension(y)
     U = typeof(unit(x) * unit(y))
     Quantity{T,D,U}(mul_float_fast(x.val, y.val))
 end
 function div_fast(x::Quantity{T}, y::Quantity{T}) where {T <: FloatTypes}
-    D = typeof(dimension(x) / dimension(y))
+    D = dimension(x) / dimension(y)
     U = typeof(unit(x) / unit(y))
     Quantity{T,D,U}(div_float_fast(x.val, y.val))
 end
@@ -103,35 +103,35 @@ le_fast(x::Quantity{T,D,U}, y::Quantity{T,D,U}) where {T <: FloatTypes,D,U} =
         Quantity{Complex{T},D,U}(Complex{T}(a.val-real(y.val), -imag(y.val)))
 
     function mul_fast(x::Quantity{T}, y::Quantity{T}) where {T <: ComplexTypes}
-        D = typeof(dimension(x) * dimension(y))
+        D = dimension(x) * dimension(y)
         U = typeof(unit(x) * unit(y))
         Quantity{T,D,U}(T(real(x.val)*real(y.val) - imag(x.val)*imag(y.val),
           real(x.val)*imag(y.val) + imag(x.val)*real(y.val)))
     end
     function mul_fast(x::Quantity{Complex{T}}, b::Quantity{T}) where {T <: FloatTypes}
-        D = typeof(dimension(x) * dimension(b))
+        D = dimension(x) * dimension(b)
         U = typeof(unit(x) * unit(b))
         Quantity{Complex{T},D,U}(Complex{T}(real(x.val)*b.val, imag(x.val)*b.val))
     end
     function mul_fast(a::Quantity{T}, y::Quantity{Complex{T}}) where {T <: FloatTypes}
-        D = typeof(dimension(a) * dimension(y))
+        D = dimension(a) * dimension(y)
         U = typeof(unit(a) * unit(y))
         Quantity{Complex{T},D,U}(Complex{T}(a.val*real(y.val), a.val*imag(y.val)))
     end
 
     @inline function div_fast(x::Quantity{T}, y::Quantity{T}) where {T <: ComplexTypes}
-        D = typeof(dimension(x) * dimension(y))
+        D = dimension(x) * dimension(y)
         U = typeof(unit(x) * unit(y))
         Quantity{T,D,U}(T(real(x.val)*real(y.val) + imag(x.val)*imag(y.val),
           imag(x.val)*real(y.val) - real(x.val)*imag(y.val))) / abs2(y)
     end
     function div_fast(x::Quantity{Complex{T}}, b::Quantity{T}) where {T <: FloatTypes}
-        D = typeof(dimension(x) / dimension(b))
+        D = dimension(x) / dimension(b)
         U = typeof(unit(x) / unit(b))
         Quantity{Complex{T},D,U}(Complex{T}(real(x.val)/b.val, imag(x.val)/b.val))
     end
     function div_fast(a::Quantity{T}, y::Quantity{Complex{T}}) where {T <: FloatTypes}
-        D = typeof(dimension(a) * dimension(y))
+        D = dimension(a) * dimension(y)
         U = typeof(unit(a) * unit(y))
         Quantity{Complex{T},D,U}(Complex{T}(a.val*real(y.val),
             -a.val*imag(y.val))) / abs2(y)

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -9,8 +9,8 @@
 @dimension 𝚯 "𝚯" Temperature    # This one is \bfTheta
 @dimension 𝐉 "𝐉" Luminosity
 @dimension 𝐍 "𝐍" Amount
-const RelativeScaleTemperature = Quantity{T, typeof(𝚯), <:AffineUnits} where T
-const AbsoluteScaleTemperature = Quantity{T, typeof(𝚯), <:ScalarUnits} where T
+const RelativeScaleTemperature = Quantity{T, 𝚯, <:AffineUnits} where T
+const AbsoluteScaleTemperature = Quantity{T, 𝚯, <:ScalarUnits} where T
 
 # Define derived dimensions.
 @derived_dimension Area                     𝐋^2
@@ -61,8 +61,8 @@ const AbsoluteScaleTemperature = Quantity{T, typeof(𝚯), <:ScalarUnits} where 
 import Base: sind, cosd, tand, secd, cscd, cotd
 for (_x,_y) in ((:sin,:sind), (:cos,:cosd), (:tan,:tand),
         (:sec,:secd), (:csc,:cscd), (:cot,:cotd))
-    @eval ($_x)(x::Quantity{T,typeof(NoDims),typeof(°)}) where {T} = ($_y)(ustrip(x))
-    @eval ($_y)(x::Quantity{T,typeof(NoDims),typeof(°)}) where {T} = ($_y)(ustrip(x))
+    @eval ($_x)(x::Quantity{T, NoDims, typeof(°)}) where {T} = ($_y)(ustrip(x))
+    @eval ($_y)(x::Quantity{T, NoDims, typeof(°)}) where {T} = ($_y)(ustrip(x))
 end
 
 # SI and related units
@@ -102,8 +102,7 @@ end
 # Area
 # The hectare is used more frequently than any other power-of-ten of an are.
 @unit a      "a"        Are         100m^2                  false
-const ha = Unitful.FreeUnits{(Unitful.Unit{:Are, Unitful.Dimensions{
-    (Unitful.Dimension{:Length}(2//1),)}}(2,1//1),), typeof(𝐋^2)}()
+const ha = Unitful.FreeUnits{(Unitful.Unit{:Are, 𝐋^2}(2, 1//1),), 𝐋^2}()
 @unit b      "b"        Barn        100fm^2                 true
 
 # Volume

--- a/src/promotion.jl
+++ b/src/promotion.jl
@@ -95,7 +95,7 @@ end
 
 # number, quantity
 function Base.promote_rule(::Type{Quantity{S,D,U}}, ::Type{T}) where {S,T <: Number,D,U}
-    if D == Dimensions{()}
+    if D == NoDims
         promote_type(S,T,typeof(convfact(NoUnits,U())))
     else
         Quantity{promote_type(S,T)}

--- a/src/quantities.jl
+++ b/src/quantities.jl
@@ -10,7 +10,7 @@ made.
     du = dimension(u)
     dx = dimension(x)
     d = du*dx
-    :(Quantity{typeof(x), typeof($d), typeof($u)}(x))
+    :(Quantity{typeof(x), $d, typeof($u)}(x))
 end
 Quantity(x::Number, y::Units) = _Quantity(x, y)
 Quantity(x::Number, y::Units{()}) = x
@@ -72,9 +72,8 @@ for f in (:mod, :rem)
 end
 
 Base.mod2pi(x::DimensionlessQuantity) = mod2pi(uconvert(NoUnits, x))
-Base.mod2pi(x::Quantity{S, Dimensions{()}, <:Units{
-    (Unitful.Unit{:Degree,Unitful.Dimensions{()}}(0, 1//1),),
-    Unitful.Dimensions{()}}}) where S = mod(x, 360°)
+Base.mod2pi(x::Quantity{S, NoDims, <:Units{(Unitful.Unit{:Degree, NoDims}(0, 1//1),),
+    NoDims}}) where S = mod(x, 360°)
 
 # Addition / subtraction
 for op in [:+, :-]
@@ -123,7 +122,7 @@ end
 function inv(x::StridedMatrix{T}) where {T <: Quantity}
     m = inv(ustrip(x))
     iq = eltype(m)
-    reinterpret(Quantity{iq, typeof(inv(dimension(T))), typeof(inv(unit(T)))}, m)
+    reinterpret(Quantity{iq, inv(dimension(T)), typeof(inv(unit(T)))}, m)
 end
 
 for x in (:istriu, :istril)
@@ -172,8 +171,8 @@ atan(y::Quantity{T,D1,U1}, x::Quantity{T,D2,U2}) where {T,D1,U1,D2,U2} =
 
 for (f, F) in [(:min, :<), (:max, :>)]
     @eval @generated function ($f)(x::Quantity, y::Quantity)    #TODO
-        xdim = x.parameters[2]()
-        ydim = y.parameters[2]()
+        xdim = x.parameters[2]
+        ydim = y.parameters[2]
         if xdim != ydim
             return :(throw(DimensionError(x,y)))
         end

--- a/src/units.jl
+++ b/src/units.jl
@@ -42,14 +42,14 @@
             next = iterate(linunits, state)
         end
         if p != 0
-            push!(c, Unit{name(oldvalue),dimtype(oldvalue)}(tens(oldvalue), p))
+            push!(c, Unit{name(oldvalue), dimtype(oldvalue)}(tens(oldvalue), p))
         end
     end
     # results in:
     # [nm,cm^6,m^6,µs^3,s]
 
     d = (c...,)
-    f = typeof(mapreduce(dimension, *, d; init=NoDims))
+    f = mapreduce(dimension, *, d; init=NoDims)
     :(FreeUnits{$d,$f,$(a0.parameters[3])}())
 end
 *(a0::ContextUnits, a::ContextUnits...) =

--- a/src/user.jl
+++ b/src/user.jl
@@ -56,10 +56,10 @@ macro dimension(symb, abbr, name)
         Unitful.abbr(::Unitful.Dimension{$x}) = $abbr
         const global $s = Unitful.Dimensions{(Unitful.Dimension{$x}(1),)}()
         const global ($name){T,U} = Union{
-            Unitful.Quantity{T,typeof($s),U},
-            Unitful.Level{L,S,Unitful.Quantity{T,typeof($s),U}} where {L,S}}
-        const global ($uname){U} = Unitful.Units{U,typeof($s)}
-        const global ($funame){U} = Unitful.FreeUnits{U,typeof($s)}
+            Unitful.Quantity{T,$s,U},
+            Unitful.Level{L,S,Unitful.Quantity{T,$s,U}} where {L,S}}
+        const global ($uname){U} = Unitful.Units{U,$s}
+        const global ($funame){U} = Unitful.FreeUnits{U,$s}
         $s
     end)
 end
@@ -84,10 +84,10 @@ macro derived_dimension(name, dims)
     funame = Symbol(name,"FreeUnits")
     esc(quote
         const global ($name){T,U} = Union{
-            Unitful.Quantity{T,typeof($dims),U},
-            Unitful.Level{L,S,Unitful.Quantity{T,typeof($dims),U}} where {L,S}}
-        const global ($uname){U} = Unitful.Units{U,typeof($dims)}
-        const global ($funame){U} = Unitful.FreeUnits{U,typeof($dims)}
+            Unitful.Quantity{T,$dims,U},
+            Unitful.Level{L,S,Unitful.Quantity{T,$dims,U}} where {L,S}}
+        const global ($uname){U} = Unitful.Units{U,$dims}
+        const global ($funame){U} = Unitful.FreeUnits{U,$dims}
         nothing
     end)
 end
@@ -127,7 +127,7 @@ macro refunit(symb, abbr, name, dimension, tf)
     n = Meta.quot(Symbol(name))
 
     push!(expr.args, quote
-        Unitful.abbr(::Unitful.Unit{$n,typeof($dimension)}) = $abbr
+        Unitful.abbr(::Unitful.Unit{$n, $dimension}) = $abbr
     end)
 
     if tf
@@ -169,7 +169,7 @@ macro unit(symb,abbr,name,equals,tf)
                                  ($equals)/Unitful.unit($equals),
                                  Unitful.tensfactor(Unitful.unit($equals)), 1))
     push!(expr.args, quote
-        Unitful.abbr(::Unitful.Unit{$n,typeof($d)}) = $abbr
+        Unitful.abbr(::Unitful.Unit{$n, $d}) = $abbr
     end)
 
     if tf
@@ -217,20 +217,20 @@ macro prefixed_unit_symbols(symb,name,dimension,basefactor)
 
     for (k,v) in prefixdict
         s = Symbol(v,symb)
-        u = :(Unitful.Unit{$n, typeof($dimension)}($k,1//1))
+        u = :(Unitful.Unit{$n, $dimension}($k,1//1))
         ea = quote
             Unitful.basefactors[$n] = $basefactor
-            const global $s = Unitful.FreeUnits{($u,),typeof(Unitful.dimension($u)),nothing}()
+            const global $s = Unitful.FreeUnits{($u,), Unitful.dimension($u), nothing}()
         end
         push!(expr.args, ea)
     end
 
     # These lines allow for μ to be typed with option-m on a Mac.
     s = Symbol(:µ, symb)
-    u = :(Unitful.Unit{$n, typeof($dimension)}(-6,1//1))
+    u = :(Unitful.Unit{$n, $dimension}(-6,1//1))
     push!(expr.args, quote
         Unitful.basefactors[$n] = $basefactor
-        const global $s = Unitful.FreeUnits{($u,),typeof(Unitful.dimension($u)),nothing}()
+        const global $s = Unitful.FreeUnits{($u,), Unitful.dimension($u), nothing}()
     end)
 
     esc(expr)
@@ -246,10 +246,10 @@ Example: `@unit_symbols ft Foot 𝐋` results in `ft` getting defined but not `k
 macro unit_symbols(symb,name,dimension,basefactor)
     s = Symbol(symb)
     n = Meta.quot(Symbol(name))
-    u = :(Unitful.Unit{$n,typeof($dimension)}(0,1//1))
+    u = :(Unitful.Unit{$n, $dimension}(0,1//1))
     esc(quote
         Unitful.basefactors[$n] = $basefactor
-        const global $s = Unitful.FreeUnits{($u,),typeof(Unitful.dimension($u)),nothing}()
+        const global $s = Unitful.FreeUnits{($u,), Unitful.dimension($u), nothing}()
     end)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -91,7 +91,7 @@ true
 
 """
     unit(x::Number)
-Returns a `Unitful.Units{(), Dimensions{()}}` object to indicate that ordinary
+Returns a `Unitful.FreeUnits{(), NoDims}` object to indicate that ordinary
 numbers have no units. This is a singleton, which we export as `NoUnits`.
 The unit is displayed as an empty string.
 
@@ -99,10 +99,10 @@ Examples:
 
 ```jldoctest
 julia> typeof(unit(1.0))
-Unitful.FreeUnits{(),Unitful.Dimensions{()}}
+Unitful.FreeUnits{(),NoDims}
 
 julia> typeof(unit(Float64))
-Unitful.FreeUnits{(),Unitful.Dimensions{()}}
+Unitful.FreeUnits{(),NoDims}
 
 julia> unit(1.0) == NoUnits
 true
@@ -117,7 +117,7 @@ true
 Given a unit or quantity, which may or may not be affine (e.g. `°C`), return the
 corresponding unit on the absolute temperature scale (e.g. `K`). Passing a
 [`Unitful.ContextUnits`](@ref) object will return another `ContextUnits` object with
-the same promotion unit, which may be an affine unit, so take care. 
+the same promotion unit, which may be an affine unit, so take care.
 """
 function absoluteunit end
 
@@ -150,8 +150,8 @@ true
 """
     dimension(u::Units{U,D}) where {U,D}
 Returns a [`Unitful.Dimensions`](@ref) object corresponding to the dimensions
-of the units, `D()`. For a dimensionless combination of units, a
-`Unitful.Dimensions{()}` object is returned.
+of the units, `D`. For a dimensionless combination of units, a
+`Unitful.Dimensions{()}` object is returned (`NoDims`).
 
 Examples:
 
@@ -162,18 +162,18 @@ julia> dimension(u"m")
 julia> typeof(dimension(u"m"))
 Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}
 
-julia> typeof(dimension(u"m/km"))
-Unitful.Dimensions{()}
+julia> dimension(u"m/km")
+NoDims
 ```
 """
-@inline dimension(u::Units{U,D}) where {U,D} = D()
+@inline dimension(u::Units{U,D}) where {U,D} = D
 
 """
     dimension(x::Quantity{T,D}) where {T,D}
     dimension(::Type{Quantity{T,D,U}}) where {T,D,U}
-Returns a [`Unitful.Dimensions`](@ref) object `D()` corresponding to the
+Returns a [`Unitful.Dimensions`](@ref) object `D` corresponding to the
 dimensions of quantity `x`. For a dimensionless [`Unitful.Quantity`](@ref), a
-`Unitful.Dimensions{()}` object is returned.
+`Unitful.Dimensions{()}` object is returned (`NoDims`).
 
 Examples:
 
@@ -185,8 +185,8 @@ julia> typeof(dimension(1.0u"m/μm"))
 Unitful.Dimensions{()}
 ```
 """
-@inline dimension(x::Quantity{T,D}) where {T,D} = D()
-@inline dimension(::Type{Quantity{T,D,U}}) where {T,D,U} = D()
+@inline dimension(x::Quantity{T,D}) where {T,D} = D
+@inline dimension(::Type{Quantity{T,D,U}}) where {T,D,U} = D
 
 @deprecate(dimension(x::AbstractArray{T}) where {T<:Number}, dimension.(x))
 @deprecate(dimension(x::AbstractArray{T}) where {T<:Units}, dimension.(x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,34 +38,18 @@ const colon = Base.:(:)
     @test isa(NoUnits, FreeUnits)
     @test typeof(𝐋) === Unitful.Dimensions{(Unitful.Dimension{:Length}(1),)}
     @test 𝐋*𝐋 === 𝐋^2
-    @test typeof(1.0m) ===
-        Unitful.Quantity{Float64,
-            typeof(𝐋),
-            Unitful.FreeUnits{(Unitful.Unit{:Meter, typeof(𝐋)}(0,1),),
-                typeof(𝐋), nothing}}
-    @test typeof(1m^2) ===
-        Unitful.Quantity{Int,
-            typeof(𝐋^2),
-            Unitful.FreeUnits{(Unitful.Unit{:Meter, typeof(𝐋)}(0,2),),
-                typeof(𝐋^2), nothing}}
-    @test typeof(1ac) ===
-        Unitful.Quantity{Int,
-            typeof(𝐋^2),
-            Unitful.FreeUnits{(Unitful.Unit{:Acre, typeof(𝐋^2)}(0,1),),
-                typeof(𝐋^2), nothing}}
+    @test typeof(1.0m) === Unitful.Quantity{Float64, 𝐋,
+        Unitful.FreeUnits{(Unitful.Unit{:Meter, 𝐋}(0,1),), 𝐋, nothing}}
+    @test typeof(1m^2) === Unitful.Quantity{Int, 𝐋^2,
+            Unitful.FreeUnits{(Unitful.Unit{:Meter, 𝐋}(0,2),), 𝐋^2, nothing}}
+    @test typeof(1ac) === Unitful.Quantity{Int, 𝐋^2,
+            Unitful.FreeUnits{(Unitful.Unit{:Acre, 𝐋^2}(0,1),), 𝐋^2, nothing}}
     @test typeof(ContextUnits(m,μm)) ===
-        ContextUnits{(Unitful.Unit{:Meter, typeof(𝐋)}(0,1),),
-            typeof(𝐋), typeof(μm), nothing}
-    @test typeof(1.0*ContextUnits(m,μm)) ===
-        Unitful.Quantity{Float64,
-            typeof(𝐋),
-            ContextUnits{(Unitful.Unit{:Meter, typeof(𝐋)}(0,1),),
-                typeof(𝐋), typeof(μm), nothing}}
-    @test typeof(1.0*FixedUnits(m)) ===
-        Unitful.Quantity{Float64,
-            typeof(𝐋),
-            FixedUnits{(Unitful.Unit{:Meter, typeof(𝐋)}(0,1),),
-                typeof(𝐋), nothing}}
+        ContextUnits{(Unitful.Unit{:Meter, 𝐋}(0,1),), 𝐋, typeof(μm), nothing}
+    @test typeof(1.0*ContextUnits(m,μm)) === Unitful.Quantity{Float64, 𝐋,
+        ContextUnits{(Unitful.Unit{:Meter, 𝐋}(0,1),), 𝐋, typeof(μm), nothing}}
+    @test typeof(1.0*FixedUnits(m)) === Unitful.Quantity{Float64, 𝐋,
+        FixedUnits{(Unitful.Unit{:Meter, 𝐋}(0,1),), 𝐋, nothing}}
     @test 3mm != 3*(m*m)                        # mm not interpreted as m*m
     @test (3+4im)*V === V*(3+4im) === (3V+4V*im)  # Complex quantity construction
     @test 3*NoUnits === 3
@@ -127,7 +111,7 @@ end
             # an essentially no-op uconvert should not disturb numeric type
             @test @inferred(uconvert(g,1g)) === 1g
             @test @inferred(uconvert(m,0x01*m)) === 0x01*m
-            @test @inferred(convert(Quantity{Float64, typeof(𝐋)}, 1m)) === 1.0m
+            @test @inferred(convert(Quantity{Float64, 𝐋}, 1m)) === 1.0m
             @test 1kg === 1kg
             @test typeof(1m)(1m) === 1m
 
@@ -197,10 +181,10 @@ end
         @test oneunit(typeof(100°C)) === 1K
         @test_throws AffineError one(100°C)
         @test_throws AffineError one(typeof(100°C))
-        
-        @test 0°C isa AffineQuantity{T, typeof(𝚯)} where T    # is "relative temperature"
+
+        @test 0°C isa AffineQuantity{T, 𝚯} where T    # is "relative temperature"
         @test 0°C isa Temperature                             # dimensional correctness
-        @test °C isa AffineUnits{N, typeof(𝚯)} where N
+        @test °C isa AffineUnits{N, 𝚯} where N
         @test °C isa TemperatureUnits
 
         @test @inferred(uconvert(°F, 0°C))  === (32//1)°F   # Some known conversions...
@@ -242,17 +226,17 @@ end
     end
     @testset "Promotion" begin
         @test_throws ErrorException Unitful.preferunits(°C)
-        @test @inferred(eltype([1°C, 1K])) <: Quantity{Rational{Int},typeof(𝚯),typeof(K)}
-        @test @inferred(eltype([1.0°C, 1K])) <: Quantity{Float64,typeof(𝚯),typeof(K)}
-        @test @inferred(eltype([1°C, 1°F])) <: Quantity{Rational{Int}, typeof(𝚯), typeof(K)}
-        @test @inferred(eltype([1.0°C, 1°F])) <: Quantity{Float64, typeof(𝚯), typeof(K)}
+        @test @inferred(eltype([1°C, 1K])) <: Quantity{Rational{Int}, 𝚯, typeof(K)}
+        @test @inferred(eltype([1.0°C, 1K])) <: Quantity{Float64, 𝚯, typeof(K)}
+        @test @inferred(eltype([1°C, 1°F])) <: Quantity{Rational{Int}, 𝚯, typeof(K)}
+        @test @inferred(eltype([1.0°C, 1°F])) <: Quantity{Float64, 𝚯, typeof(K)}
 
         # context units should be identifiable as affine
         @test ContextUnits(°C, °F) isa AffineUnits
 
         let fc = ContextUnits(°F, °C), cc = ContextUnits(°C, °C)
             @test @inferred(promote(1fc, 1cc)) === ((-155//9)cc, (1//1)cc)
-            @test @inferred(eltype([1cc, 1°C])) <: Quantity{Rational{Int}, typeof(𝚯), typeof(cc)}
+            @test @inferred(eltype([1cc, 1°C])) <: Quantity{Rational{Int}, 𝚯, typeof(cc)}
         end
     end
 end
@@ -360,7 +344,7 @@ end
     @testset "> Some internal behaviors" begin
         # quantities
         @test Unitful.numtype(Quantity{Float64}) <: Float64
-        @test Unitful.numtype(Quantity{Float64,typeof(𝐋)}) <: Float64
+        @test Unitful.numtype(Quantity{Float64, 𝐋}) <: Float64
         @test Unitful.numtype(typeof(1.0kg)) <: Float64
         @test Unitful.numtype(1.0kg) <: Float64
     end
@@ -1122,6 +1106,15 @@ end
     end
 end
 
+@testset "Display" begin
+    @test string(typeof(1.0m/s)) ==
+        "Unitful.Quantity{Float64,𝐋*𝐓^-1,Unitful.FreeUnits{(m, s^-1),𝐋*𝐓^-1,nothing}}"
+    @test string(typeof(m/s)) ==
+        "Unitful.FreeUnits{(m, s^-1),𝐋*𝐓^-1,nothing}"
+    @test string(dimension(1u"m/s")) == "𝐋 𝐓^-1"
+    @test string(NoDims) == "NoDims"
+end
+
 @testset "DimensionError message" begin
     function errorstr(e)
         b = IOBuffer()
@@ -1131,7 +1124,7 @@ end
     @test errorstr(DimensionError(1u"m",2)) ==
         "DimensionError: 1 m and 2 are not dimensionally compatible."
     @test errorstr(DimensionError(1u"m",NoDims)) ==
-        "DimensionError: 1 m and  are not dimensionally compatible."
+        "DimensionError: 1 m and NoDims are not dimensionally compatible."
     @test errorstr(DimensionError(u"m",2)) ==
         "DimensionError: m and 2 are not dimensionally compatible."
 end
@@ -1445,9 +1438,7 @@ let fname = tempname()
             redirect_stderr(f) do
                 # wrap in eval to catch the STDERR output...
                 @test eval(:(typeof(u"m"))) == Unitful.FreeUnits{
-                    (Unitful.Unit{:MyMeter,Unitful.Dimensions{
-                    (Unitful.Dimension{:Length}(1//1),)}}(0,1//1),),
-                    Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}, nothing}
+                    (Unitful.Unit{:MyMeter, 𝐋}(0, 1//1),), 𝐋, nothing}
             end
         end
     finally


### PR DESCRIPTION
Basic idea: `Quantity{T, Dimensions{...}, U}` --> `Quantity{T, Dimensions{...}(), U}`
This improves clarity by dramatically shortening how types are displayed, which makes error messages, etc. more readable.

For example, before we had:

`typeof(1m) <: Quantity{Int64,Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)},Unitful.FreeUnits{(Unitful.Unit{:Meter,Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)}}(0, 1//1),),Unitful.Dimensions{(Unitful.Dimension{:Length}(1//1),)},nothing}}`

With this PR we would have:

`typeof(1m) <: Quantity{Int64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}`

Some logic has been added to always display `NoDims` as `NoDims` instead of showing nothing. This improves clarity in general and in particular when displaying the type of a dimensionless quantity. Additionally, when a product of dimensions appears in a type signature, a `*` is used instead of a space:

```
julia> typeof(1m/s)
Quantity{Int64,𝐋*𝐓^-1,Unitful.FreeUnits{(m, s^-1),𝐋*𝐓^-1,nothing}}

julia> dimension(1u"m/s")
𝐋 𝐓^-1
```

There should be no loss of usability because you cannot do a whole lot with the type parameter of a `Dimensions` type anyway.