### PR TITLE
Safer `ustrip`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,8 @@
 using Documenter, Unitful
 
-makedocs()
+makedocs(
+    sitename = "Unitful",
+)
 
 deploydocs(
     deps   = Deps.pip("Tornado>=4.0.0,<5.0.0", "mkdocs==0.17.5", "mkdocs-material==2.9.4", "python-markdown-math"),

--- a/src/logarithm.jl
+++ b/src/logarithm.jl
@@ -479,11 +479,12 @@ struct InvalidOp end
 Base.show(io::IO, ::InvalidOp) = print(io, "†")
 macro _doctables(x)
     return esc(quote
+        sprint(show,
         try
             $x
         catch
             Unitful.InvalidOp()
-        end
+        end)
     end)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -7,15 +7,35 @@
 @inline dimtype(u::Unit{U,D}) where {U,D} = D
 
 """
-    ustrip(x::Number)
-    ustrip(x::Quantity)
-Returns the number out in front of any units. The value of `x` may differ from the number
-out front of the units in the case of dimensionless quantities, e.g. `1m/mm != 1`. See
-[`uconvert`](@ref) and the example below. Because the units are removed, information may be
-lost and this should be used with some care.
+    ustrip(u::Units, x::Quantity)
+    ustrip(T::Type, u::Units, x::Quantity)
+
+Convert `x` to units `u` using [`uconvert`](@ref) and return the number out the
+front of the resulting quantity. If `T` is supplied, also `convert` the
+resulting number into type `T`.
 
 This function is mainly intended for compatibility with packages that don't know
 how to handle quantities.
+
+```jldoctest
+julia> ustrip(u"m", 1u"mm") == 1//1000
+true
+
+julia> ustrip(Float64, u"m", 2u"mm") == 0.002
+true
+```
+"""
+@inline ustrip(u::Units, x::Quantity) = ustrip(uconvert(u, x))
+@inline ustrip(T::Type, u::Units, x::Quantity) = convert(T, ustrip(u, x))
+
+"""
+    ustrip(x::Number)
+    ustrip(x::Quantity)
+
+Returns the number out in front of any units. The value of `x` may differ from the number
+out front of the units in the case of dimensionless quantities, e.g. `1m/mm != 1`. See
+[`uconvert`](@ref) and the example below. Because the units are removed, information may be
+lost and this should be used with some care — see `ustrip(u,x)` for a safer alternative.
 
 ```jldoctest
 julia> ustrip(2u"μm/m") == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,11 +76,19 @@ end
         @test_throws DimensionError convert(Float64, 3m)
         @test @inferred(3m/unit(3m)) === 3
         @test @inferred(3.0g/unit(3.0g)) === 3.0
+        # 1-arg ustrip
         @test @inferred(ustrip(3*FreeUnits(m))) === 3
         @test @inferred(ustrip(3*ContextUnits(m,μm))) === 3
         @test @inferred(ustrip(3*FixedUnits(m))) === 3
         @test @inferred(ustrip(3)) === 3
         @test @inferred(ustrip(3.0m)) === 3.0
+        # ustrip with type and unit arguments
+        @test @inferred(ustrip(m, 3.0m)) === 3.0
+        @test @inferred(ustrip(m, 2mm)) === 1//500
+        @test @inferred(ustrip(mm, 3.0m)) === 3000.0
+        @test @inferred(ustrip(Float64, m, 2mm)) === 0.002
+        @test @inferred(ustrip(Int, mm, 2.0m)) === 2000
+        # convert
         @test convert(typeof(1mm/m), 3) == 3000mm/m
         @test convert(typeof(1mm/m), 3*NoUnits) == 3000mm/m
         @test convert(typeof(1*ContextUnits(mm/m, NoUnits)), 3) == 3000mm/m


### PR DESCRIPTION
One approach to fix #48 by providing a safer form for `ustrip`, while not introducing extra conversion rules or special cases.

Also a couple of fixes to documentation generation, which seems to have been broken by recent `Documenter` updates (I guess?)

As a separate step we could consider deprecating the one argument form of `ustrip`, though I guess it's not so easy to deprecate `ustrip` for arrays without copying.