### PR TITLE
implement Base.complex, Base.widen, Base.reim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 deps/
 docs/build/
 docs/site/
+*~

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -45,6 +45,7 @@ include("conversion.jl")
 include("range.jl")
 include("fastmath.jl")
 include("logarithm.jl")
+include("complex.jl")
 include("pkgdefaults.jl")
 
 function __init__()

--- a/src/Unitful.jl
+++ b/src/Unitful.jl
@@ -4,6 +4,7 @@ import Base: ==, <, <=, +, -, *, /, //, ^, isequal
 import Base: show, convert
 import Base: abs, abs2, angle, float, fma, muladd, inv, sqrt, cbrt
 import Base: min, max, floor, ceil, real, imag, conj
+import Base: complex, widen, reim # handled in complex.jl
 import Base: exp, exp10, exp2, expm1, log, log10, log1p, log2
 import Base: sin, cos, tan, cot, sec, csc, atan, cis
 

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -5,13 +5,15 @@
 #
 # It is currently incomplete.
 
-Base.complex(z::AbstractQuantity{T,D,U}) where {T<:Complex,D,U} = z
-function Base.complex(x::Quantity{T,D,U}, y = zero(real)) where {
+complex(z::Quantity{T,D,U}) where {T<:Complex,D,U} = z
+function complex(x::Quantity{T,D,U}, y = zero(real)) where {
     T<:Real,D,U
 }
     r, i = promote(x, y)
     return Quantity{complex(T),D,U}(complex(ustrip(r), ustrip(i)))
 end
+complex(::Type{Quantity{T,D,U}}) where {T,D,U} =
+    Quantity{complex(Type{T}),D,U}
 
 # implement Base.widen for real and complex quantities because Unitful
 # does not have an implementation for widen yet

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -1,0 +1,42 @@
+# This file is meant to provide all the methods in
+# https://github.com/JuliaLang/julia/blob/master/base/complex.jl that
+# are defined for Real or Complex numbers, just for
+# AbstractQuantities{T,D,U} where T is Real or Complex, respectively.
+#
+# It is currently incomplete.
+
+Base.complex(z::AbstractQuantity{T,D,U}) where {T<:Complex,D,U} = z
+function Base.complex(x::Quantity{T,D,U}, y = zero(real)) where {
+    T<:Real,D,U
+}
+    r, i = promote(x, y)
+    return Quantity{complex(T),D,U}(complex(ustrip(r), ustrip(i)))
+end
+
+# implement Base.widen for real and complex quantities because Unitful
+# does not have an implementation for widen yet
+Base.widen(::Type{Quantity{T,D,U}}) where {T,D,U} =
+    Quantity{widen(T),D,U}
+
+# skip Base.float because it is already implemented
+
+#Base.real(z::Quantity{T,D,U}) where {T<:Complex,D,U} =
+#    Quantity{T,D,U}(real(ustrip(z)))
+
+#Base.imag(z::Quantity{T,D,U}) where {T<:Complex,D,U} =
+#    Quantity{T,D,U}(imag(ustrip(z)))
+
+Base.reim(z::Quantity{T,D,U}) where {T<:Complex,D,U} =
+    Quantity{T,D,U}(reim(ustrip(z)))
+
+# Base.real for types has a general implementation in julia; a faster
+# method could be provided but is not strictly required.
+
+# Base.isreal, etc., are already implemented in Unitful.
+
+# Base.flipsign is already implemented in Unitful.
+
+# To Do: Check if Base.show, Base.read, Base.write, etc. need any
+#        attention
+
+# ...

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -13,7 +13,7 @@ function complex(x::Quantity{T,D,U}, y = zero(x)) where {
     return Quantity{complex(T),D,U}(complex(ustrip(r), ustrip(i)))
 end
 complex(::Type{Quantity{T,D,U}}) where {T,D,U} =
-    Quantity{complex(Type{T}),D,U}
+    Quantity{complex(T),D,U}
 
 # implement Base.widen for real and complex quantities because Unitful
 # does not have an implementation for widen yet

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -6,7 +6,7 @@
 # It is currently incomplete.
 
 complex(z::Quantity{T,D,U}) where {T<:Complex,D,U} = z
-function complex(x::Quantity{T,D,U}, y = zero(real)) where {
+function complex(x::Quantity{T,D,U}, y = zero(x)) where {
     T<:Real,D,U
 }
     r, i = promote(x, y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,8 @@ const colon = Base.:(:)
     @test (3+4im)*V === V*(3+4im) === (3V+4V*im)  # Complex quantity construction
     @test !isreal(Base.complex(3.0/m, 4.0/m))
     @test !isreal(Base.complex((3.0+4.0im)/m))
+    @test Base.reim(Base.complex((3.0+4.0im)/m)) == (3.0/m, 4.0/m)
+    @test Base.widen(Base.complex(Float32(3.0)/m)) == Base.complex(Float64(3.0)/m)
     @test 3*NoUnits === 3
     @test 3*(FreeUnits(m)/FreeUnits(m)) === 3
     @test 3*(ContextUnits(m)/ContextUnits(m)) === 3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,8 @@ const colon = Base.:(:)
         FixedUnits{(Unitful.Unit{:Meter, 𝐋}(0,1),), 𝐋, nothing}}
     @test 3mm != 3*(m*m)                        # mm not interpreted as m*m
     @test (3+4im)*V === V*(3+4im) === (3V+4V*im)  # Complex quantity construction
+    @test !isreal(Base.complex(3.0/m, 4.0/m))
+    @test !isreal(Base.complex((3.0+4.0im)/m))
     @test 3*NoUnits === 3
     @test 3*(FreeUnits(m)/FreeUnits(m)) === 3
     @test 3*(ContextUnits(m)/ContextUnits(m)) === 3
@@ -67,6 +69,11 @@ const colon = Base.:(:)
     @test ContextUnits(m, FixedUnits(mm)) === ContextUnits(m, mm)
     @test ContextUnits(m, ContextUnits(mm, mm)) === ContextUnits(m, mm)
     @test_throws DimensionError ContextUnits(m,kg)
+end
+
+@testset "Types" begin
+    @test Base.complex(Quantity{Float64,NoDims,NoUnits}) ==
+        Quantity{Complex{Float64},NoDims,NoUnits}
 end
 
 @testset "Conversion" begin


### PR DESCRIPTION
This PR helps dealing with complex, Unitful quantities by implementing missing methods.

Complex and yet Unitful quantities do occur e.g. as generalized frequencies or in the Ray Transfer matrix treatment of Gaussian beams.